### PR TITLE
feat: 修复折叠菜单状态重置、新增收藏功能、优化 Tab 切换动画及悬浮球定位

### DIFF
--- a/src/components/Account/Area.tsx
+++ b/src/components/Account/Area.tsx
@@ -12,7 +12,7 @@ interface AreaProps {
     alias: string,
     keys: string,
     areaName: string,
-    showOnlyFav: boolean
+    showOnlyFav?: boolean // 优化：设为可选属性
 }
 
 export interface TocItem {
@@ -20,16 +20,14 @@ export interface TocItem {
     id: string
 }
 
-export default function Area({ alias, keys: key, areaName, showOnlyFav }: AreaProps) {
+export default function Area({ alias, keys: key, areaName, showOnlyFav = false }: AreaProps) { // 优化：赋默认值 false
 
     const [config, setConfig] = useState<ModuleResponse | null>(null);
-    // 1. 增加 isFetching 状态，专门用来做切 Tab 的无感过渡
     const [isFetching, setIsFetching] = useState(false);
     const { open, onOpen, onClose } = useDisclosure();
 
     useEffect(() => {
         let isMounted = true;
-        // 开启加载锁：旧内容立刻开始变暗
         setIsFetching(true);
 
         if (alias && key) {
@@ -54,13 +52,11 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav }: AreaPr
                     }
                 }
                 
-                // 直接覆盖旧 config，不经过 null 状态
                 setConfig(finalRes);
             }).catch((err) => {
                 if (isMounted) console.log(err);
             }).finally(() => {
                 if (isMounted) {
-                    // 解锁：恢复亮度
                     setIsFetching(false);
                 }
             });
@@ -81,7 +77,6 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav }: AreaPr
         });
     };
 
-    // 根据 showOnlyFav 过滤模块列表
     const visibleModules = showOnlyFav
         ? config?.order.filter(moduleKey => config.config[`_fav_${moduleKey}`] === true) ?? []
         : config?.order ?? [];
@@ -93,18 +88,14 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav }: AreaPr
             id: moduleKey
         }));
 
-    // 只有第一次进页面、手头上彻底没有任何数据时，才展示骨架屏
     const isInitialLoading = !config && isFetching;
 
     return (
         <Box
-            // 核心动画细节：
-            // 1. 切换时 0.15s 迅速变暗（35% opacity）+ 轻微下沉 4px，给用户明确的"正在换页"反馈
-            // 2. 数据到位后 0.15s 瞬间变亮并复位，全程旧组件垫底，无任何空白/闪烁
             opacity={isFetching && config ? 0.35 : 1}
-            transform={isFetching && config ? "translateY(15px)" : "translateY(0)"}
+            transform={isFetching && config ? "translateY(5px)" : "translateY(0)"}
             transition="opacity 0.15s ease-out, transform 0.15s ease-out"
-            pointerEvents={isFetching ? 'none' : 'auto'} // 变暗期间禁止误触
+            pointerEvents={isFetching ? 'none' : 'auto'}
             pb={20}
         >
             <Stack gap={4}>
@@ -119,21 +110,27 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav }: AreaPr
                         </Box>
                     ))
                 ) : (
-                    visibleModules.map((module) => (
-                        <Module 
-                            key={module} 
-                            id={module} 
-                            alias={alias} 
-                            areaKey={key} 
-                            areaName={areaName} 
-                            config={config?.config ?? {}} 
-                            info={(config?.info[module])} 
-                            isOpen={open} 
-                            onOpen={onOpen} 
-                            onClose={onClose} 
-                            onConfigUpdate={handleConfigUpdate} 
-                        />
-                    ))
+                    visibleModules.map((module) => {
+                        const moduleInfo = config?.info?.[module];
+                        // 优化：做判空类型收窄，解决 TS2322 报错
+                        if (!moduleInfo) return null;
+
+                        return (
+                            <Module 
+                                key={module} 
+                                id={module} 
+                                alias={alias} 
+                                areaKey={key} 
+                                areaName={areaName} 
+                                config={config?.config ?? {}} 
+                                info={moduleInfo} 
+                                isOpen={open} 
+                                onOpen={onOpen} 
+                                onClose={onClose} 
+                                onConfigUpdate={handleConfigUpdate} 
+                            />
+                        );
+                    })
                 )}
             </Stack>
 

--- a/src/components/Account/Area.tsx
+++ b/src/components/Account/Area.tsx
@@ -3,16 +3,16 @@ import { useEffect, useState } from 'react'
 
 import { FiCompass } from 'react-icons/fi';
 import Module from "./Module"
-import { ModuleResponse } from '@interfaces/Module';
+import { ConfigValue, ModuleResponse } from '@interfaces/Module';
 import { Skeleton } from '../../components/ui/skeleton';
 import Toc from "./Toc"
 import { getAccountConfig } from '@api/Account'
-import { keyframes } from '@emotion/react'
 
 interface AreaProps {
     alias: string,
     keys: string,
-    areaName: string
+    areaName: string,
+    showOnlyFav: boolean
 }
 
 export interface TocItem {
@@ -20,59 +20,130 @@ export interface TocItem {
     id: string
 }
 
-export default function Area({ alias, keys: key, areaName }: AreaProps) {
+export default function Area({ alias, keys: key, areaName, showOnlyFav }: AreaProps) {
 
     const [config, setConfig] = useState<ModuleResponse | null>(null);
-    const { open, onOpen, onClose } = useDisclosure()
+    // 1. 增加 isFetching 状态，专门用来做切 Tab 的无感过渡
+    const [isFetching, setIsFetching] = useState(false);
+    const { open, onOpen, onClose } = useDisclosure();
 
     useEffect(() => {
+        let isMounted = true;
+        // 开启加载锁：旧内容立刻开始变暗
+        setIsFetching(true);
+
         if (alias && key) {
             getAccountConfig(alias, key).then((res) => {
-                setConfig(res)
+                if (!isMounted) return;
+
+                const favKey = `autopcr_fav_${alias}`;
+                const stored = localStorage.getItem(favKey);
+                let finalRes = res;
+
+                if (stored) {
+                    try {
+                        const favMap = JSON.parse(stored) as Record<string, string[]>;
+                        const areaFavs = favMap[key] || [];
+                        const mergedConfig = { ...res.config };
+                        areaFavs.forEach(moduleKey => {
+                            mergedConfig[`_fav_${moduleKey}`] = true;
+                        });
+                        finalRes = { ...res, config: mergedConfig };
+                    } catch {
+                        finalRes = res;
+                    }
+                }
+                
+                // 直接覆盖旧 config，不经过 null 状态
+                setConfig(finalRes);
             }).catch((err) => {
-                console.log(err);
-            })
+                if (isMounted) console.log(err);
+            }).finally(() => {
+                if (isMounted) {
+                    // 解锁：恢复亮度
+                    setIsFetching(false);
+                }
+            });
         }
+
+        return () => {
+            isMounted = false;
+        };
     }, [alias, key]);
 
-    const tocList: TocItem[] = [];
-    config?.order.map((module) => {
-        tocList.push({ name: config.info[module].name, id: module })
-    })
+    const handleConfigUpdate = (configKey: string, value: ConfigValue) => {
+        setConfig(prev => {
+            if (!prev) return prev;
+            return {
+                ...prev,
+                config: { ...prev.config, [configKey]: value }
+            };
+        });
+    };
 
-    const fade = keyframes`
-      from { opacity: 0; transform: translateY(20px); }
-      to { opacity: 1; transform: translateY(0); }
-    `
+    // 根据 showOnlyFav 过滤模块列表
+    const visibleModules = showOnlyFav
+        ? config?.order.filter(moduleKey => config.config[`_fav_${moduleKey}`] === true) ?? []
+        : config?.order ?? [];
+
+    const tocList: TocItem[] = visibleModules
+        .filter((moduleKey) => config?.info?.[moduleKey])
+        .map((moduleKey) => ({
+            name: config?.info[moduleKey]?.name || moduleKey,
+            id: moduleKey
+        }));
+
+    // 只有第一次进页面、手头上彻底没有任何数据时，才展示骨架屏
+    const isInitialLoading = !config && isFetching;
 
     return (
-        <Box animation={`${fade} 0.5s ease-out`} pb={20}>
+        <Box
+            // 核心动画细节：
+            // 1. 切换时 0.15s 迅速变暗（35% opacity）+ 轻微下沉 4px，给用户明确的"正在换页"反馈
+            // 2. 数据到位后 0.15s 瞬间变亮并复位，全程旧组件垫底，无任何空白/闪烁
+            opacity={isFetching && config ? 0.35 : 1}
+            transform={isFetching && config ? "translateY(15px)" : "translateY(0)"}
+            transition="opacity 0.15s ease-out, transform 0.15s ease-out"
+            pointerEvents={isFetching ? 'none' : 'auto'} // 变暗期间禁止误触
+            pb={20}
+        >
             <Stack gap={4}>
-                {!config ? (
+                {isInitialLoading ? (
                     Array.from({ length: 4 }).map((_, i) => (
                         <Box key={i} p={6} borderWidth="1px" borderRadius="2xl" bg="bg.panel" shadow="sm">
                             <Skeleton height="30px" width="40%" mb={4} />
-                             <Skeleton height="20px" width="100%" mb={2} />
-                             <Skeleton height="20px" width="80%" mb={2} />
-                             <Skeleton height="20px" width="90%" mb={6} />
-                             <Skeleton height="40px" width="100%" />
+                            <Skeleton height="20px" width="100%" mb={2} />
+                            <Skeleton height="20px" width="80%" mb={2} />
+                            <Skeleton height="20px" width="90%" mb={6} />
+                            <Skeleton height="40px" width="100%" />
                         </Box>
                     ))
                 ) : (
-                    config?.order.map((module) => (
-                        <Module key={module} id={module} alias={alias} areaKey={key} areaName={areaName} config={config?.config} info={(config.info[module])} isOpen={open} onOpen={onOpen} onClose={onClose} />
+                    visibleModules.map((module) => (
+                        <Module 
+                            key={module} 
+                            id={module} 
+                            alias={alias} 
+                            areaKey={key} 
+                            areaName={areaName} 
+                            config={config?.config ?? {}} 
+                            info={(config?.info[module])} 
+                            isOpen={open} 
+                            onOpen={onOpen} 
+                            onClose={onClose} 
+                            onConfigUpdate={handleConfigUpdate} 
+                        />
                     ))
                 )}
             </Stack>
 
-            {/* Floating TOC Button */}
             <Flex position="fixed"
                 right="6"
                 top="50%"
                 transform="translateY(-50%)"
                 justifyContent="center"
                 alignItems="center"
-                 zIndex={100}
+                zIndex={100}
             >
                 <Popover.Root lazyMount positioning={{ placement: 'left', gutter: 4 }}>
                     <Popover.Trigger>

--- a/src/components/Account/Area.tsx
+++ b/src/components/Account/Area.tsx
@@ -7,12 +7,13 @@ import { ConfigValue, ModuleResponse } from '@interfaces/Module';
 import { Skeleton } from '../../components/ui/skeleton';
 import Toc from "./Toc"
 import { getAccountConfig } from '@api/Account'
+import { keyframes } from '@emotion/react'
 
 interface AreaProps {
     alias: string,
     keys: string,
     areaName: string,
-    showOnlyFav?: boolean // 优化：设为可选属性
+    showOnlyFav?: boolean
 }
 
 export interface TocItem {
@@ -20,7 +21,13 @@ export interface TocItem {
     id: string
 }
 
-export default function Area({ alias, keys: key, areaName, showOnlyFav = false }: AreaProps) { // 优化：赋默认值 false
+// 首次加载的轻量入场动画
+const fadeInUp = keyframes`
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+`
+
+export default function Area({ alias, keys: key, areaName, showOnlyFav = false }: AreaProps) {
 
     const [config, setConfig] = useState<ModuleResponse | null>(null);
     const [isFetching, setIsFetching] = useState(false);
@@ -91,51 +98,55 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
     const isInitialLoading = !config && isFetching;
 
     return (
-        <Box
-            opacity={isFetching && config ? 0.35 : 1}
-            transform={isFetching && config ? "translateY(5px)" : "translateY(0)"}
-            transition="opacity 0.15s ease-out, transform 0.15s ease-out"
-            pointerEvents={isFetching ? 'none' : 'auto'}
-            pb={20}
-        >
-            <Stack gap={4}>
-                {isInitialLoading ? (
-                    Array.from({ length: 4 }).map((_, i) => (
-                        <Box key={i} p={6} borderWidth="1px" borderRadius="2xl" bg="bg.panel" shadow="sm">
-                            <Skeleton height="30px" width="40%" mb={4} />
-                            <Skeleton height="20px" width="100%" mb={2} />
-                            <Skeleton height="20px" width="80%" mb={2} />
-                            <Skeleton height="20px" width="90%" mb={6} />
-                            <Skeleton height="40px" width="100%" />
-                        </Box>
-                    ))
-                ) : (
-                    visibleModules.map((module) => {
-                        const moduleInfo = config?.info?.[module];
-                        // 优化：做判空类型收窄，解决 TS2322 报错
-                        if (!moduleInfo) return null;
+        <>
+            {/* 1. 内容模块区域：仅对内容做透明度过渡与入场动画 */}
+            <Box
+                animation={config && !isFetching ? `${fadeInUp} 0.25s ease-out` : undefined}
+                opacity={isFetching && config ? 0.35 : 1}
+                transition="opacity 0.15s ease-out"
+                pointerEvents={isFetching ? 'none' : 'auto'}
+                pb={20}
+            >
+                <Stack gap={4}>
+                    {isInitialLoading ? (
+                        Array.from({ length: 4 }).map((_, i) => (
+                            <Box key={i} p={6} borderWidth="1px" borderRadius="2xl" bg="bg.panel" shadow="sm">
+                                <Skeleton height="30px" width="40%" mb={4} />
+                                <Skeleton height="20px" width="100%" mb={2} />
+                                <Skeleton height="20px" width="80%" mb={2} />
+                                <Skeleton height="20px" width="90%" mb={6} />
+                                <Skeleton height="40px" width="100%" />
+                            </Box>
+                        ))
+                    ) : (
+                        visibleModules.map((module) => {
+                            const moduleInfo = config?.info?.[module];
+                            if (!moduleInfo) return null;
 
-                        return (
-                            <Module 
-                                key={module} 
-                                id={module} 
-                                alias={alias} 
-                                areaKey={key} 
-                                areaName={areaName} 
-                                config={config?.config ?? {}} 
-                                info={moduleInfo} 
-                                isOpen={open} 
-                                onOpen={onOpen} 
-                                onClose={onClose} 
-                                onConfigUpdate={handleConfigUpdate} 
-                            />
-                        );
-                    })
-                )}
-            </Stack>
+                            return (
+                                <Module 
+                                    key={module} 
+                                    id={module} 
+                                    alias={alias} 
+                                    areaKey={key} 
+                                    areaName={areaName} 
+                                    config={config?.config ?? {}} 
+                                    info={moduleInfo} 
+                                    isOpen={open} 
+                                    onOpen={onOpen} 
+                                    onClose={onClose} 
+                                    onConfigUpdate={handleConfigUpdate} 
+                                />
+                            );
+                        })
+                    )}
+                </Stack>
+            </Box>
 
-            <Flex position="fixed"
-                right="6"
+            {/* 2. 悬浮 TOC 导航球：移至最外层 Fragment，实现真·Viewport 屏幕中央固定，零闪跳且适应各种 DPI/分辨率 */}
+            <Flex 
+                position="fixed"
+                right={{ base: "3", md: "6" }} // 适配小屏幕/高 DPI 缩放，防止挤压卡片内容
                 top="50%"
                 transform="translateY(-50%)"
                 justifyContent="center"
@@ -147,7 +158,7 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
                         <IconButton 
                             aria-label='TOC'
                             colorPalette="blue"
-                            size="xl"
+                            size={{ base: "lg", md: "xl" }} // 响应式尺寸
                             rounded="full"
                             shadow="xl"
                             transition="all 0.2s"
@@ -161,6 +172,6 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
                     </Popover.Content>
                 </Popover.Root>
             </Flex>
-        </Box>
+        </>
     )
 }

--- a/src/components/Account/Area.tsx
+++ b/src/components/Account/Area.tsx
@@ -21,9 +21,9 @@ export interface TocItem {
     id: string
 }
 
-// 首次加载的轻量入场动画
+// 仅用于整页首次进入时的轻微入场动画
 const fadeInUp = keyframes`
-  from { opacity: 0; transform: translateY(12px); }
+  from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }
 `
 
@@ -31,6 +31,8 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
 
     const [config, setConfig] = useState<ModuleResponse | null>(null);
     const [isFetching, setIsFetching] = useState(false);
+    // 关键锁：记录是否是真正的“首次加载”
+    const [isFirstLoad, setIsFirstLoad] = useState(true);
     const { open, onOpen, onClose } = useDisclosure();
 
     useEffect(() => {
@@ -65,6 +67,8 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
             }).finally(() => {
                 if (isMounted) {
                     setIsFetching(false);
+                    // 首次加载成功后锁死，后续 Tab 切换再也不会触发 keyframe 动画
+                    setIsFirstLoad(false);
                 }
             });
         }
@@ -99,10 +103,13 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
 
     return (
         <>
-            {/* 1. 内容模块区域：仅对内容做透明度过渡与入场动画 */}
+            {/* 1. 模块列表区域：
+                   - 首次加载完毕：跑 1 次 fadeInUp；
+                   - 后续切换 Tab：animation 为 undefined，仅通过 opacity 纯平滑过渡，无任何弹跳闪烁 
+            */}
             <Box
-                animation={config && !isFetching ? `${fadeInUp} 0.25s ease-out` : undefined}
-                opacity={isFetching && config ? 0.35 : 1}
+                animation={isFirstLoad && config ? `${fadeInUp} 0.25s ease-out` : undefined}
+                opacity={isFetching && config ? 0.4 : 1}
                 transition="opacity 0.15s ease-out"
                 pointerEvents={isFetching ? 'none' : 'auto'}
                 pb={20}
@@ -143,10 +150,10 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
                 </Stack>
             </Box>
 
-            {/* 2. 悬浮 TOC 导航球：移至最外层 Fragment，实现真·Viewport 屏幕中央固定，零闪跳且适应各种 DPI/分辨率 */}
+            {/* 2. 悬浮 TOC 导航球：在最外层，位置绝对锁定屏幕右侧中央，适配各种 DPI/分辨率，切 Tab 零闪跳零位移 */}
             <Flex 
                 position="fixed"
-                right={{ base: "3", md: "6" }} // 适配小屏幕/高 DPI 缩放，防止挤压卡片内容
+                right={{ base: "3", md: "6" }}
                 top="50%"
                 transform="translateY(-50%)"
                 justifyContent="center"
@@ -158,7 +165,7 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
                         <IconButton 
                             aria-label='TOC'
                             colorPalette="blue"
-                            size={{ base: "lg", md: "xl" }} // 响应式尺寸
+                            size={{ base: "lg", md: "xl" }}
                             rounded="full"
                             shadow="xl"
                             transition="all 0.2s"

--- a/src/components/Account/Area.tsx
+++ b/src/components/Account/Area.tsx
@@ -1,76 +1,70 @@
 import { Box, Flex, IconButton, Popover, Stack, useDisclosure } from '@chakra-ui/react';
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react';
 
 import { FiCompass } from 'react-icons/fi';
-import Module from "./Module"
+import Module from "./Module";
 import { ConfigValue, ModuleResponse } from '@interfaces/Module';
 import { Skeleton } from '../../components/ui/skeleton';
-import Toc from "./Toc"
-import { getAccountConfig } from '@api/Account'
-import { keyframes } from '@emotion/react'
+import Toc from "./Toc";
+import { getAccountConfig } from '@api/Account';
 
 interface AreaProps {
-    alias: string,
-    keys: string,
-    areaName: string,
-    showOnlyFav?: boolean
+    alias: string;
+    keys: string;
+    areaName: string;
+    showOnlyFav?: boolean;
 }
 
 export interface TocItem {
-    name: string,
-    id: string
+    name: string;
+    id: string;
 }
 
-// 仅用于整页首次进入时的轻微入场动画
-const fadeInUp = keyframes`
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: translateY(0); }
-`
-
 export default function Area({ alias, keys: key, areaName, showOnlyFav = false }: AreaProps) {
+    const [state, setState] = useState<{
+        config: ModuleResponse | null;
+        isLoading: boolean;
+    }>({
+        config: null,
+        isLoading: true,
+    });
 
-    const [config, setConfig] = useState<ModuleResponse | null>(null);
-    const [isFetching, setIsFetching] = useState(false);
-    // 关键锁：记录是否是真正的“首次加载”
-    const [isFirstLoad, setIsFirstLoad] = useState(true);
     const { open, onOpen, onClose } = useDisclosure();
 
     useEffect(() => {
         let isMounted = true;
-        setIsFetching(true);
 
         if (alias && key) {
-            getAccountConfig(alias, key).then((res) => {
-                if (!isMounted) return;
+            getAccountConfig(alias, key)
+                .then((res) => {
+                    if (!isMounted) return;
 
-                const favKey = `autopcr_fav_${alias}`;
-                const stored = localStorage.getItem(favKey);
-                let finalRes = res;
+                    const favKey = `autopcr_fav_${alias}`;
+                    const stored = localStorage.getItem(favKey);
+                    let finalRes = res;
 
-                if (stored) {
-                    try {
-                        const favMap = JSON.parse(stored) as Record<string, string[]>;
-                        const areaFavs = favMap[key] || [];
-                        const mergedConfig = { ...res.config };
-                        areaFavs.forEach(moduleKey => {
-                            mergedConfig[`_fav_${moduleKey}`] = true;
-                        });
-                        finalRes = { ...res, config: mergedConfig };
-                    } catch {
-                        finalRes = res;
+                    if (stored) {
+                        try {
+                            const favMap = JSON.parse(stored) as Record<string, string[]>;
+                            const areaFavs = favMap[key] || [];
+                            const mergedConfig = { ...res.config };
+                            areaFavs.forEach((moduleKey) => {
+                                mergedConfig[`_fav_${moduleKey}`] = true;
+                            });
+                            finalRes = { ...res, config: mergedConfig };
+                        } catch {
+                            finalRes = res;
+                        }
                     }
-                }
-                
-                setConfig(finalRes);
-            }).catch((err) => {
-                if (isMounted) console.log(err);
-            }).finally(() => {
-                if (isMounted) {
-                    setIsFetching(false);
-                    // 首次加载成功后锁死，后续 Tab 切换再也不会触发 keyframe 动画
-                    setIsFirstLoad(false);
-                }
-            });
+
+                    setState({ config: finalRes, isLoading: false });
+                })
+                .catch((err) => {
+                    if (isMounted) {
+                        console.error(err);
+                        setState((prev) => ({ ...prev, isLoading: false }));
+                    }
+                });
         }
 
         return () => {
@@ -79,43 +73,43 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
     }, [alias, key]);
 
     const handleConfigUpdate = (configKey: string, value: ConfigValue) => {
-        setConfig(prev => {
-            if (!prev) return prev;
+        setState((prev) => {
+            if (!prev.config) return prev;
             return {
                 ...prev,
-                config: { ...prev.config, [configKey]: value }
+                config: {
+                    ...prev.config,
+                    config: { ...prev.config.config, [configKey]: value },
+                },
             };
         });
     };
 
-    const visibleModules = showOnlyFav
-        ? config?.order.filter(moduleKey => config.config[`_fav_${moduleKey}`] === true) ?? []
-        : config?.order ?? [];
+    const config = state.config;
 
-    const tocList: TocItem[] = visibleModules
-        .filter((moduleKey) => config?.info?.[moduleKey])
-        .map((moduleKey) => ({
-            name: config?.info[moduleKey]?.name || moduleKey,
-            id: moduleKey
-        }));
+    const visibleModules = useMemo(() => {
+        if (!config) return [];
+        return showOnlyFav
+            ? config.order.filter((moduleKey) => config.config[`_fav_${moduleKey}`] === true)
+            : config.order;
+    }, [config, showOnlyFav]);
 
-    const isInitialLoading = !config && isFetching;
+    const tocList: TocItem[] = useMemo(() => {
+        if (!config) return [];
+        return visibleModules
+            .filter((moduleKey) => config.info?.[moduleKey])
+            .map((moduleKey) => ({
+                name: config.info[moduleKey]?.name || moduleKey,
+                id: moduleKey,
+            }));
+    }, [config, visibleModules]);
 
     return (
         <>
-            {/* 1. 模块列表区域：
-                   - 首次加载完毕：跑 1 次 fadeInUp；
-                   - 后续切换 Tab：animation 为 undefined，仅通过 opacity 纯平滑过渡，无任何弹跳闪烁 
-            */}
-            <Box
-                animation={isFirstLoad && config ? `${fadeInUp} 0.25s ease-out` : undefined}
-                opacity={isFetching && config ? 0.4 : 1}
-                transition="opacity 0.15s ease-out"
-                pointerEvents={isFetching ? 'none' : 'auto'}
-                pb={20}
-            >
+            <Box pb={20} position="relative">
                 <Stack gap={4}>
-                    {isInitialLoading ? (
+                    {/* 首次加载未获取到数据时：只显示灰色骨架块，避免任何白屏 */}
+                    {state.isLoading && !config ? (
                         Array.from({ length: 4 }).map((_, i) => (
                             <Box key={i} p={6} borderWidth="1px" borderRadius="2xl" bg="bg.panel" shadow="sm">
                                 <Skeleton height="30px" width="40%" mb={4} />
@@ -131,18 +125,18 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
                             if (!moduleInfo) return null;
 
                             return (
-                                <Module 
-                                    key={module} 
-                                    id={module} 
-                                    alias={alias} 
-                                    areaKey={key} 
-                                    areaName={areaName} 
-                                    config={config?.config ?? {}} 
-                                    info={moduleInfo} 
-                                    isOpen={open} 
-                                    onOpen={onOpen} 
-                                    onClose={onClose} 
-                                    onConfigUpdate={handleConfigUpdate} 
+                                <Module
+                                    key={module}
+                                    id={module}
+                                    alias={alias}
+                                    areaKey={key}
+                                    areaName={areaName}
+                                    config={config?.config ?? {}}
+                                    info={moduleInfo}
+                                    isOpen={open}
+                                    onOpen={onOpen}
+                                    onClose={onClose}
+                                    onConfigUpdate={handleConfigUpdate}
                                 />
                             );
                         })
@@ -150,8 +144,7 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
                 </Stack>
             </Box>
 
-            {/* 2. 悬浮 TOC 导航球：在最外层，位置绝对锁定屏幕右侧中央，适配各种 DPI/分辨率，切 Tab 零闪跳零位移 */}
-            <Flex 
+            <Flex
                 position="fixed"
                 right={{ base: "3", md: "6" }}
                 top="50%"
@@ -162,13 +155,13 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
             >
                 <Popover.Root lazyMount positioning={{ placement: 'left', gutter: 4 }}>
                     <Popover.Trigger>
-                        <IconButton 
-                            aria-label='TOC'
+                        <IconButton
+                            aria-label="TOC"
                             colorPalette="blue"
                             size={{ base: "lg", md: "xl" }}
                             rounded="full"
                             shadow="xl"
-                            transition="all 0.2s"
+                            transition="transform 0.2s ease"
                             _hover={{ transform: "scale(1.1)", shadow: "2xl" }}
                         >
                             <FiCompass />
@@ -180,5 +173,5 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
                 </Popover.Root>
             </Flex>
         </>
-    )
+    );
 }

--- a/src/components/Account/Config.tsx
+++ b/src/components/Account/Config.tsx
@@ -1,215 +1,438 @@
-import { Box, Button, Checkbox as ChakraCheckbox, Input, NativeSelect, Stack, Text, Textarea } from '@chakra-ui/react'
-import { ChangeEventHandler, FocusEventHandler, useState } from 'react';
-import { ConfigInfo, ConfigValue } from '@/interfaces/Module';
-import { NumberInput, NumberInputField } from '../../components/ui/number-input';
-
+import { Box, Button, Checkbox as ChakraCheckbox, Input, NativeSelect, Stack, Text, Textarea } from '@chakra-ui/react';
 import { AxiosError } from 'axios';
+import NiceModal from '@ebay/nice-modal-react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { putAccountConfig } from '@/api/Account';
+import { ConfigInfo, ConfigValue } from '@/interfaces/Module';
 import { Checkbox } from '../../components/ui/checkbox';
 import { InputGroup } from '../../components/ui/input-group';
-import NiceModal from '@ebay/nice-modal-react';
+import { NumberInput, NumberInputField } from '../../components/ui/number-input';
 import { Switch } from '../../components/ui/switch';
-import multiSelectModal from './MultiSelectModal';
-import { putAccountConfig } from '@/api/Account';
 import { toaster } from '../../components/ui/toaster';
+import multiSelectModal from './MultiSelectModal';
 
 interface ConfigProps {
+    alias: string;
+    value: ConfigValue;
+    info: ConfigInfo;
+}
+
+/**
+ * 通用受控配置 Hook
+ * - 管理本地 state，外部 value 变化时自动同步
+ * - 提供 save 方法，带乐观更新 + 失败回滚 + 卸载保护
+ */
+function useConfigState<T>(
     alias: string,
-    value: ConfigValue,
-    info: ConfigInfo
+    key: string,
+    propValue: T,
+    transform?: (val: T) => ConfigValue
+) {
+    const [state, setState] = useState<T>(propValue);
+    const mountedRef = useRef(true);
+
+    useEffect(() => {
+        setState(propValue);
+    }, [propValue]);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
+
+    const save = async (newValue: T): Promise<void> => {
+        setState(newValue);
+        const payload = transform ? transform(newValue) : (newValue as ConfigValue);
+        try {
+            const res = await putAccountConfig(alias, key, payload);
+            if (mountedRef.current) {
+                toaster.create({ type: 'success', title: '保存成功', description: res });
+            }
+        } catch (err) {
+            const axiosErr = err as AxiosError;
+            if (mountedRef.current) {
+                setState(propValue);
+                toaster.create({
+                    type: 'error',
+                    title: '保存失败',
+                    description: axiosErr.response?.data as string || '网络错误',
+                });
+            }
+        }
+    };
+
+    return [state, setState, save] as const;
 }
 
-// 在现有的Config组件中添加表格类型的处理
-export default function Config({ alias, value, info }: ConfigProps) {
-    switch (info?.config_type) {
-        case 'bool':
-            return <ConfigBool alias={alias} value={value} info={info} />
-        case 'int':
-            return <ConfigInt alias={alias} value={value} info={info} />
-        case 'single':
-            return <ConfigSingle alias={alias} value={value} info={info} />
-        case 'multi':
-            return <ConfigMulti alias={alias} value={value} info={info} />
-        case 'time':
-            return <ConfigTime alias={alias} value={value} info={info} />
-        case 'text':
-            return <ConfigText alias={alias} value={value} info={info} />
-        case 'multi_search':
-            return <ConfigMultiSearch alias={alias} value={value} info={info} />
-    }
-}
-
+// ---------- ConfigBool ----------
 function ConfigBool({ alias, value, info }: ConfigProps) {
-    const onCheckedChange = (details: { checked: boolean }) => {
-        putAccountConfig(alias, info.key, details.checked).then((res) => {
-            toaster.create({ type: 'success', title: '保存成功', description: res });
-        }).catch((err: AxiosError) => {
-            toaster.create({ type: 'error', title: '保存失败', description: err.response?.data as string || "网络错误" });
-        });
-    }
+    const [checked, , save] = useConfigState(alias, info.key, value as boolean);
 
     return (
-        <InputGroup startElement={info.desc} endElement={
-            <Switch id={info.key} defaultChecked={value as boolean} onCheckedChange={onCheckedChange} />
-        }>
-        </InputGroup>
-    )
+        <InputGroup
+            startElement={info.desc}
+            endElement={
+                <Switch
+                    id={info.key}
+                    checked={checked}
+                    onCheckedChange={(d) => save(d.checked)}
+                />
+            }
+        />
+    );
 }
 
+// ---------- ConfigInt（改为 onBlur 保存）----------
 function ConfigInt({ alias, value, info }: ConfigProps) {
-    const onChange = (_: string, valueAsNumber: number) => {
-        putAccountConfig(alias, info.key, valueAsNumber).then((res) => {
-            toaster.create({ type: 'success', title: '保存成功', description: res });
-        }).catch((err: AxiosError) => {
-            toaster.create({ type: 'error', title: '保存失败', description: err.response?.data as string || "网络错误" });
-        });
-    }
+    const min = Math.min(...(info.candidates.map((c) => c.value) as number[]));
+    const max = Math.max(...(info.candidates.map((c) => c.value) as number[]));
 
-    // NumberInput deprecated onChange signature: (valueAsString, valueAsNumber).
-    // V3 NumberInput snippet might not support onValueChange with number?
-    // Chakra V3 NumberInput.Root has onValueChange: (details: { value: string; valueAsNumber: number }) => void.
-    // My snippet uses ChakraNumberInput.Root.
-    // So onValueChange={(e) => onChange(e.value, e.valueAsNumber)}
-    
+    // 受控的字符串显示值
+    const [numStr, setNumStr] = useState(String(value));
+    const [saving, setSaving] = useState(false); // 可选 loading 态
+    const mountedRef = useRef(true);
+
+    // 外部 value 同步
+    useEffect(() => {
+        setNumStr(String(value));
+    }, [value]);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
+
+    // 处理失焦保存
+    const handleBlur = () => {
+        let finalValue: string | number;
+
+        // 空值或无效值处理为最小值
+        if (numStr === '' || isNaN(Number(numStr))) {
+            finalValue = min;
+            setNumStr(String(min)); // UI 也回显最小值
+        } else {
+            finalValue = Number(numStr);
+        }
+
+        // 边界检查（可选，但保留原有行为）
+        if (finalValue < min) finalValue = min;
+        if (finalValue > max) finalValue = max;
+
+        // 发送保存
+        const payload: ConfigValue = finalValue as ConfigValue;
+        putAccountConfig(alias, info.key, payload)
+            .then((res) => {
+                if (mountedRef.current) {
+                    toaster.create({ type: 'success', title: '保存成功', description: res });
+                }
+            })
+            .catch((err: AxiosError) => {
+                if (mountedRef.current) {
+                    // 失败回滚到外部 value
+                    setNumStr(String(value));
+                    toaster.create({
+                        type: 'error',
+                        title: '保存失败',
+                        description: err.response?.data as string || '网络错误',
+                    });
+                }
+            });
+    };
+
+    // 输入过程中仅更新本地状态
+    const handleChange = (e: { value: string }) => {
+        setNumStr(e.value);
+    };
+
     return (
         <InputGroup startElement={info.desc}>
-            <NumberInput onValueChange={(e) => onChange(e.value, e.valueAsNumber)} id={info.key} defaultValue={String(value)} min={Math.min(...info.candidates.map(c => c.value) as number[])} max={Math.max(...info.candidates.map(c => c.value) as number[])}>
-                <NumberInputField />
+            <NumberInput
+                value={numStr}
+                onValueChange={handleChange}
+                id={info.key}
+                min={min}
+                max={max}
+            >
+                <NumberInputField onBlur={handleBlur} />
             </NumberInput>
         </InputGroup>
-    )
+    );
 }
 
+// ---------- ConfigSingle ----------
 function ConfigSingle({ alias, value, info }: ConfigProps) {
-    const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-        let value: ConfigValue = e.target.value;
-        const intValue = Number(value);
-        if (!isNaN(intValue))
-            value = intValue;
-        putAccountConfig(alias, info.key, value).then((res) => {
-            toaster.create({ type: 'success', title: '保存成功', description: res });
-        }).catch((err: AxiosError) => {
-            toaster.create({ type: 'error', title: '保存失败', description: err.response?.data as string || "网络错误" });
-        });
-    }
+    const [selectValue, , save] = useConfigState(alias, info.key, value as string | number);
 
     return (
         <InputGroup startElement={info.desc}>
             <NativeSelect.Root>
-            <NativeSelect.Field onChange={onChange} id={info.key} defaultValue={value as string | number}>
-                {
-                    info.candidates.map((element) => {
-                        return <option key={element.value as string | number} value={element.value as string | number} >{element.display}</option>
-                    })
-                }
-            </NativeSelect.Field>
+                <NativeSelect.Field
+                    onChange={(e) => {
+                        let newValue: ConfigValue = e.target.value;
+                        const intVal = Number(newValue);
+                        if (!isNaN(intVal)) newValue = intVal;
+                        save(newValue);
+                    }}
+                    id={info.key}
+                    value={selectValue}
+                >
+                    {info.candidates.map((element) => (
+                        <option
+                            key={element.value as string | number}
+                            value={element.value as string | number}
+                        >
+                            {element.display}
+                        </option>
+                    ))}
+                </NativeSelect.Field>
             </NativeSelect.Root>
         </InputGroup>
-    )
+    );
 }
 
+// ---------- ConfigMulti ----------
 function ConfigMulti({ alias, value, info }: ConfigProps) {
-    const onChange = (value: (string | number)[]) => {
-        let postValue = value;
-        const intValue = postValue.map(option => Number(option))
-        if (intValue.length != 0 && !isNaN(intValue[0]))
-            postValue = intValue;
+    const initialStrArr = useMemo(
+        () => (value as (string | number)[]).map(String),
+        [JSON.stringify(value)]
+    );
 
-        putAccountConfig(alias, info.key, postValue as ConfigValue).then((res) => {
-            toaster.create({ type: 'success', title: '保存成功', description: res });
-        }).catch((err: AxiosError) => {
-            toaster.create({ type: 'error', title: '保存失败', description: err.response?.data as string || "网络错误" });
-        });
-    }
-    // CheckboxGroup onChange expects (value: string[]). My code expects (string | number)[]. 
-    // V3 Checkbox.Group onValueChange: (details: { value: string[] }) => void.
-    // So I need to adapt.
-    
+    const [groupValue, setGroupValue] = useState(initialStrArr);
+    const mountedRef = useRef(true);
+
+    useEffect(() => {
+        setGroupValue(initialStrArr);
+    }, [initialStrArr]);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => { mountedRef.current = false; };
+    }, []);
+
+    const handleSave = (newStrArr: string[]) => {
+        let postValue: ConfigValue = newStrArr;
+        const intArr = newStrArr.map(Number);
+        if (intArr.length > 0 && !isNaN(intArr[0])) postValue = intArr;
+
+        setGroupValue(newStrArr);
+        putAccountConfig(alias, info.key, postValue)
+            .then((res) => {
+                if (mountedRef.current)
+                    toaster.create({ type: 'success', title: '保存成功', description: res });
+            })
+            .catch((err: AxiosError) => {
+                if (mountedRef.current) {
+                    setGroupValue(initialStrArr);
+                    toaster.create({
+                        type: 'error',
+                        title: '保存失败',
+                        description: err.response?.data as string || '网络错误',
+                    });
+                }
+            });
+    };
+
+    const onCheckboxChange = (param: string[] | { value: string[] }) => {
+        const newValue = Array.isArray(param) ? param : param.value;
+        handleSave(newValue);
+    };
+
     return (
         <InputGroup startElement={info.desc}>
-            <Box paddingLeft="16px" paddingRight="32px" overflowY="scroll" borderWidth="1px" borderColor="border.subtle" borderRadius="md" w="full">
-                <ChakraCheckbox.Group onValueChange={(e) => onChange(e)} defaultValue={(value as (string | number)[]).map(option => String(option))} >
+            <Box
+                paddingLeft="16px"
+                paddingRight="32px"
+                overflowY="scroll"
+                borderWidth="1px"
+                borderColor="border.subtle"
+                borderRadius="md"
+                w="full"
+            >
+                <ChakraCheckbox.Group onValueChange={onCheckboxChange} value={groupValue}>
                     <Stack gap={[1, 5]} direction={['column', 'row']}>
-                        {
-                            info.candidates.map((element) => {
-                                return <Checkbox key={element.value as string | number} value={String(element.value)} >{element.display}</Checkbox>
-                            })
-                        }
+                        {info.candidates.map((element) => (
+                            <Checkbox
+                                key={element.value as string | number}
+                                value={String(element.value)}
+                            >
+                                {element.display}
+                            </Checkbox>
+                        ))}
                     </Stack>
                 </ChakraCheckbox.Group>
             </Box>
-        </InputGroup >
-    )
+        </InputGroup>
+    );
 }
 
+// ---------- ConfigTime ----------
 function ConfigTime({ alias, value, info }: ConfigProps) {
-    const onBlur: ChangeEventHandler<HTMLInputElement> = (e: React.ChangeEvent<HTMLInputElement>) => {
-        putAccountConfig(alias, info.key, e.target.value as ConfigValue).then((res) => {
-            toaster.create({ type: 'success', title: '保存成功', description: res });
-        }).catch((err: AxiosError) => {
-            toaster.create({ type: 'error', title: '保存失败', description: err.response?.data as string || "网络错误" });
-        });
-    }
+    const [timeStr, setTimeStr] = useState(value as string);
+
+    useEffect(() => {
+        setTimeStr(value as string);
+    }, [value]);
+
+    const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+        const newValue = e.target.value;
+        putAccountConfig(alias, info.key, newValue as ConfigValue)
+            .then((res) => {
+                toaster.create({ type: 'success', title: '保存成功', description: res });
+            })
+            .catch((err: AxiosError) => {
+                setTimeStr(value as string);
+                toaster.create({
+                    type: 'error',
+                    title: '保存失败',
+                    description: err.response?.data as string || '网络错误',
+                });
+            });
+    };
 
     return (
         <InputGroup startElement={info.desc}>
-            <Input type='time' onBlur={onBlur} id={info.key} defaultValue={value as string} />
+            <Input
+                type="time"
+                value={timeStr}
+                onChange={(e) => setTimeStr(e.target.value)}
+                onBlur={handleBlur}
+                id={info.key}
+            />
         </InputGroup>
-    )
+    );
 }
 
+// ---------- ConfigText ----------
 function ConfigText({ alias, value, info }: ConfigProps) {
-    const onBlur: FocusEventHandler<HTMLTextAreaElement> = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-        putAccountConfig(alias, info.key, e.target.value as ConfigValue).then((res) => {
-            toaster.create({ type: 'success', title: '保存成功', description: res });
-        }).catch((err: AxiosError) => {
-            toaster.create({ type: 'error', title: '保存失败', description: err.response?.data as string || "网络错误" });
-        });
-    }
-    const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-        e.target.style.height = 'auto'; // 重置高度
-        e.target.style.height = `${e.target.scrollHeight}px`; // 根据内容设置高度
-    };    
+    const [textStr, setTextStr] = useState(value as string);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    useEffect(() => {
+        setTextStr(value as string);
+    }, [value]);
+
+    useLayoutEffect(() => {
+        const el = textareaRef.current;
+        if (el) {
+            el.style.height = 'auto';
+            el.style.height = `${el.scrollHeight}px`;
+        }
+    }, [textStr]);
+
+    const handleBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
+        const newValue = e.target.value;
+        putAccountConfig(alias, info.key, newValue as ConfigValue)
+            .then((res) => {
+                toaster.create({ type: 'success', title: '保存成功', description: res });
+            })
+            .catch((err: AxiosError) => {
+                setTextStr(value as string);
+                toaster.create({
+                    type: 'error',
+                    title: '保存失败',
+                    description: err.response?.data as string || '网络错误',
+                });
+            });
+    };
+
     return (
         <>
             <Text>{info.desc}</Text>
-            <Textarea onBlur={onBlur} id={info.key} defaultValue={value as string} onInput={handleInput} />
+            <Textarea
+                ref={textareaRef}
+                value={textStr}
+                onChange={(e) => setTextStr(e.target.value)}
+                onBlur={handleBlur}
+                id={info.key}
+            />
         </>
     );
 }
 
+// ---------- ConfigMultiSearch ----------
 function ConfigMultiSearch({ alias, value, info }: ConfigProps) {
     const [localValue, setLocalValue] = useState<ConfigValue>(value);
+    const mountedRef = useRef(true);
+
+    useEffect(() => {
+        setLocalValue(value);
+    }, [value]);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => { mountedRef.current = false; };
+    }, []);
 
     const displayValue = ((localValue || []) as number[]).map((id) => {
         const unit = info.candidates.find((unit) => unit.value === id);
         return unit ? (unit.nickname ? unit.nickname : unit.display) : String(id);
     });
 
-    const handleClick = async (e: React.MouseEvent): Promise<void> => {
+    const handleClick = async (e: React.MouseEvent) => {
         e.stopPropagation();
-        
+        const previousValue = localValue;
         try {
-            const ret: ConfigValue = await NiceModal.show(multiSelectModal, {
+            const ret = (await NiceModal.show(multiSelectModal, {
                 candidates: info.candidates,
                 value: localValue as ConfigValue[],
-            }) as ConfigValue;
+            })) as ConfigValue;
             if (ret === undefined) return;
-            
-            const res: string = await putAccountConfig(alias, info.key, ret);
-            setLocalValue(ret);
-            toaster.create({ type: "success", title: "保存成功", description: res });
+
+            const res = await putAccountConfig(alias, info.key, ret);
+            if (mountedRef.current) {
+                setLocalValue(ret);
+                toaster.create({ type: 'success', title: '保存成功', description: res });
+            }
             await NiceModal.hide(multiSelectModal);
         } catch (err) {
             const axiosErr = err as AxiosError;
-            toaster.create({ type: "error", title: "保存失败", description: axiosErr.response?.data as string || "网络错误" });
+            if (mountedRef.current) {
+                setLocalValue(previousValue);
+                toaster.create({
+                    type: 'error',
+                    title: '保存失败',
+                    description: axiosErr.response?.data as string || '网络错误',
+                });
+            }
         }
     };
 
     return (
-        <InputGroup startElement={info.desc} endElement={
-            <Button size="sm" onClick={handleClick}>选择</Button>
-        }>
+        <InputGroup
+            startElement={info.desc}
+            endElement={
+                <Button size="sm" onClick={handleClick}>
+                    选择
+                </Button>
+            }
+        >
             <Input value={displayValue.join(', ')} readOnly onClick={handleClick} cursor="pointer" />
         </InputGroup>
     );
+}
+
+// ---------- 主组件 ----------
+export default function Config({ alias, value, info }: ConfigProps) {
+    switch (info?.config_type) {
+        case 'bool':
+            return <ConfigBool alias={alias} value={value} info={info} />;
+        case 'int':
+            return <ConfigInt alias={alias} value={value} info={info} />;
+        case 'single':
+            return <ConfigSingle alias={alias} value={value} info={info} />;
+        case 'multi':
+            return <ConfigMulti alias={alias} value={value} info={info} />;
+        case 'time':
+            return <ConfigTime alias={alias} value={value} info={info} />;
+        case 'text':
+            return <ConfigText alias={alias} value={value} info={info} />;
+        case 'multi_search':
+            return <ConfigMultiSearch alias={alias} value={value} info={info} />;
+        default:
+            return null;
+    }
 }

--- a/src/components/Account/Config.tsx
+++ b/src/components/Account/Config.tsx
@@ -91,7 +91,7 @@ function ConfigInt({ alias, value, info }: ConfigProps) {
 
     // 受控的字符串显示值
     const [numStr, setNumStr] = useState(String(value));
-    const [saving, setSaving] = useState(false); // 可选 loading 态
+    //const [saving, setSaving] = useState(false); // 可选 loading 态
     const mountedRef = useRef(true);
 
     // 外部 value 同步

--- a/src/components/Account/ConfigImportExport.tsx
+++ b/src/components/Account/ConfigImportExport.tsx
@@ -67,7 +67,7 @@ const ConfigImportExport = ({ alias, areas, onImportSuccess }: ConfigIOProps) =>
         switch (type) {
             case 'bool':
             case 'single':
-                if (typeof value === "boolean") return value;
+                if (typeof value === "string" || typeof value === "number") return value;
                 break
             case 'int':
                 if (typeof value === "number") return value;

--- a/src/components/Account/ConfigImportExport.tsx
+++ b/src/components/Account/ConfigImportExport.tsx
@@ -18,7 +18,7 @@ import { toaster } from "../../components/ui/toaster";
 interface ConfigIOProps {
     alias: string;
     areas: AreaInfo[];
-    onImportSuccess?: () => void; // 添加回调函数属性
+    onImportSuccess?: () => void;
 }
 
 const ConfigImportExport = ({ alias, areas, onImportSuccess }: ConfigIOProps) => {
@@ -35,10 +35,23 @@ const ConfigImportExport = ({ alias, areas, onImportSuccess }: ConfigIOProps) =>
             if (!configs) {
                 return;
             }
+            
+            // 从 localStorage 读取收藏状态，合并到导出文件
+            const favKey = `autopcr_fav_${alias}`;
+            const storedFav = localStorage.getItem(favKey);
+            const favMap = storedFav ? JSON.parse(storedFav) as Record<string, string[]> : {};
+            
             const allConfig: Record<string, Record<string, ConfigValue>> = {};
             configs.forEach((value, index) => {
-                allConfig[areas[index].key] = value.config;
-            })
+                const areaKey = areas[index].key;
+                allConfig[areaKey] = { ...value.config };
+                // 补收藏标记
+                const areaFavs = favMap[areaKey] || [];
+                areaFavs.forEach(moduleKey => {
+                    allConfig[areaKey][`_fav_${moduleKey}`] = true;
+                });
+            });
+            
             const strCfg = btoa(encodeURIComponent(JSON.stringify(allConfig)));
             const blob = new Blob([strCfg], { type: 'text/plain;charset=utf-8' });
             saveAs(blob, `autopcr_${alias}.autopcrcfg`);
@@ -84,10 +97,11 @@ const ConfigImportExport = ({ alias, areas, onImportSuccess }: ConfigIOProps) =>
         }
         return undefined
     }
+    
     const realImportByModule = (module: ModuleResponse, configs: Record<string, ConfigValue>): Record<string, ConfigValue> => {
         const uploadConfig: Record<string, ConfigValue> = {};
         for (const moduleKey in module.info) {
-            if (configs[moduleKey] && typeof configs[moduleKey] === "boolean") {
+            if (configs[moduleKey] !== undefined && typeof configs[moduleKey] === "boolean") {
                 uploadConfig[moduleKey] = configs[moduleKey]
             }
             const moduleConf = module.info[moduleKey].config
@@ -101,24 +115,55 @@ const ConfigImportExport = ({ alias, areas, onImportSuccess }: ConfigIOProps) =>
         }
         return uploadConfig;
     }
+    
     const realImport = async (rawCfg: string) => {
         try {
+            // 优化 1：解析输入，增加对损坏文件或非法格式的捕获
+            let configs: Record<string, Record<string, ConfigValue>>;
+            try {
+                const cleanStr = rawCfg.trim();
+                configs = JSON.parse(decodeURIComponent(atob(cleanStr))) as Record<string, Record<string, ConfigValue>>;
+            } catch {
+                throw new Error("配置文件格式无效，请检查选取的配置文件或输入的文本内容。");
+            }
+
             const configItems = await Promise.all(
                 areas.map((area) => getAccountConfig(alias, area.key))
             );
-            const configs = JSON.parse(decodeURIComponent(atob(rawCfg))) as Record<string, Record<string, ConfigValue>>;
             const uploadConfig: Record<string, ConfigValue> = {};
+            const importedFav: Record<string, string[]> = {};
 
             configItems.forEach((value, index) => {
                 const areaKey = areas[index].key;
-                if (configs[areaKey] === undefined) {
+                const areaConfig = configs[areaKey];
+                if (!areaConfig) {
                     return;
                 }
-                Object.assign(uploadConfig, realImportByModule(value, configs[areaKey]));
-            })
+                
+                // 1. Schema 校验的基础配置
+                const validatedAreaConfig = realImportByModule(value, areaConfig);
+                Object.assign(uploadConfig, validatedAreaConfig);
+                
+                // 2. 补全收藏标记与补充细节配置
+                for (const key in areaConfig) {
+                    if (key.startsWith('_fav_')) {
+                        importedFav[areaKey] = importedFav[areaKey] || [];
+                        if (areaConfig[key] === true) {
+                            importedFav[areaKey].push(key.slice(5));
+                        }
+                    } else if (uploadConfig[key] === undefined && areaConfig[key] !== undefined) {
+                        uploadConfig[key] = areaConfig[key];
+                    }
+                }
+            });
 
+            // 保存收藏状态到 localStorage
+            localStorage.setItem(`autopcr_fav_${alias}`, JSON.stringify(importedFav));
+            
             await putAccountConfigs(alias, uploadConfig);
             toaster.create({ type: 'success', title: '配置导入成功' });
+            
+            // 优化 2：无缝通知父级重新拉取数据刷新页面
             onImportSuccess?.();
         } catch (err) {
             if (err instanceof AxiosError) {
@@ -144,7 +189,6 @@ const ConfigImportExport = ({ alias, areas, onImportSuccess }: ConfigIOProps) =>
 
     const importTextDialogDisclosure = useDisclosure();
     const [textImportVal, setTextImportVal] = useState('');
-    // const textImportRef = useRef<FocusableElement>(null); // Removed unused ref
     const onTextImport = () => {
         importTextDialogDisclosure.onClose();
         void realImport(textImportVal);
@@ -154,7 +198,6 @@ const ConfigImportExport = ({ alias, areas, onImportSuccess }: ConfigIOProps) =>
         importTextDialogDisclosure.onClose()
         setTextImportVal('')
     }
-
 
     const bgColor = "bg.panel";
 
@@ -213,4 +256,3 @@ const ConfigImportExport = ({ alias, areas, onImportSuccess }: ConfigIOProps) =>
 }
 
 export default ConfigImportExport;
-

--- a/src/components/Account/Module.tsx
+++ b/src/components/Account/Module.tsx
@@ -179,7 +179,7 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
         >
             <Card.Header py={3} cursor="pointer" onClick={onToggleExpand}>
                 <Flex align="center" wrap="wrap" gap={2}>
-                    <Box onClick={(e) => e.stopPropagation()} mr={{ base: 1, md: 3 }}>
+                    <Box onClick={(e) => e.stopPropagation()} mr={{ base: 1, md: 1 }}>
                          {/* 受控组件绑定，保证导入/更新后界面同步勾选 */}
                          <Checkbox 
                             checked={!!config[info.key]} 

--- a/src/components/Account/Module.tsx
+++ b/src/components/Account/Module.tsx
@@ -195,8 +195,6 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
                             
                             {/* 收藏黄星 */}
                             <Box
-                                as="button"
-                                type="button"
                                 onClick={handleToggleFav}
                                 cursor="pointer"
                                 color={config?.[`_fav_${info.key}`] ? "yellow.400" : "gray.400"}
@@ -204,8 +202,6 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
                                 lineHeight={1}
                                 display="flex"
                                 alignItems="center"
-                                bg="transparent"
-                                border="none"
                                 p={0}
                             >
                                 <FiStar fill={config?.[`_fav_${info.key}`] ? "currentColor" : "none"} />

--- a/src/components/Account/Module.tsx
+++ b/src/components/Account/Module.tsx
@@ -1,8 +1,6 @@
-import * as React from 'react';
-
 import { Box, Button, Card, Collapsible, Flex, HStack, Heading, Separator, Stack, Tag, useDisclosure } from '@chakra-ui/react'
 import { ConfigValue, ModuleInfo } from '@interfaces/Module';
-import { FiChevronDown, FiCopy } from 'react-icons/fi';
+import { FiChevronDown, FiCopy, FiStar } from 'react-icons/fi';
 import { getAccountAreaSingleResultList, postAccountAreaSingle, putAccountConfig, getAccountConfig, putAccountConfigs } from '@api/Account';
 
 import Alert from '../alert';
@@ -22,18 +20,49 @@ interface ModuleProps extends React.ComponentProps<typeof Card.Root> {
     info: ModuleInfo
     isOpen: boolean,
     onOpen: () => void,
-    onClose: () => void
+    onClose: () => void,
+    onConfigUpdate?: (key: string, value: ConfigValue) => void
 }
 
-export default function Module({ alias, areaKey, areaName, config, info, isOpen, onOpen, onClose, ...rest }: ModuleProps) {
+export default function Module({ alias, areaKey, areaName, config, info, isOpen, onOpen, onClose, onConfigUpdate, ...rest }: ModuleProps) {
     const { open: isExpanded, onToggle: onToggleExpand } = useDisclosure({ defaultOpen: false });
     const dangerConfirm = useDisclosure();
     const isDangerous = areaName === '危险';
 
+    const handleToggleFav = async (e: React.MouseEvent) => {
+        e.stopPropagation();
+        const favKey = `autopcr_fav_${alias}`;
+        const stored = localStorage.getItem(favKey);
+        const favMap = stored ? JSON.parse(stored) as Record<string, string[]> : {};
+        const areaFavs = new Set(favMap[areaKey] || []);
+        
+        const isNowFav = !areaFavs.has(info.key);
+        if (isNowFav) {
+            areaFavs.add(info.key);
+        } else {
+            areaFavs.delete(info.key);
+        }
+        
+        favMap[areaKey] = Array.from(areaFavs);
+        localStorage.setItem(favKey, JSON.stringify(favMap));
+        
+        // 同步通知父组件更新本地状态，使星星立即变色
+        onConfigUpdate?.(`_fav_${info.key}`, isNowFav);
+    };
+
     const onCheckedChange = (details: { checked: boolean | "indeterminate" }) => {
-        putAccountConfig(alias, info?.key, !!details.checked).then((response) => {
+        const isChecked = !!details.checked;
+        const previousValue = config[info.key];
+
+        // 1. 乐观更新：0ms 立即在界面打勾/取消打勾
+        onConfigUpdate?.(info.key, isChecked);
+
+        // 2. 异步请求后端，失败时回滚
+        putAccountConfig(alias, info?.key, isChecked).then((response) => {
             toaster.create({ type: 'success', title: '保存成功', description: response });
         }).catch((err: AxiosError) => {
+            // 请求失败：回滚勾选状态
+            onConfigUpdate?.(info.key, previousValue);
             toaster.create({ type: 'error', title: '保存失败', description: err.response?.data as string || "网络错误" });
         })
     };
@@ -151,16 +180,38 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
             <Card.Header py={3} cursor="pointer" onClick={onToggleExpand}>
                 <Flex align="center" wrap="wrap" gap={2}>
                     <Box onClick={(e) => e.stopPropagation()} mr={{ base: 1, md: 3 }}>
+                         {/* 受控组件绑定，保证导入/更新后界面同步勾选 */}
                          <Checkbox 
-                            defaultChecked={!!config[info.key]} 
+                            checked={!!config[info.key]} 
                             onCheckedChange={onCheckedChange}
                             size="lg"
                             colorPalette="blue"
                         />
                     </Box>
                     <Box flex="1" minW="0">
-                        <HStack gap={1} flexWrap="wrap">
-                            <Heading size={{ base: 'sm', md: 'md' }} fontWeight="bold" truncate>{info?.name}</Heading> 
+                        <HStack gap={2} flexWrap="wrap" align="center">
+                            {/* 模块名称 */}
+                            <Heading size={{ base: 'sm', md: 'md' }} fontWeight="bold" truncate>{info?.name}</Heading>
+                            
+                            {/* 收藏黄星 */}
+                            <Box
+                                as="button"
+                                type="button"
+                                onClick={handleToggleFav}
+                                cursor="pointer"
+                                color={config?.[`_fav_${info.key}`] ? "yellow.400" : "gray.400"}
+                                fontSize="1.25rem"
+                                lineHeight={1}
+                                display="flex"
+                                alignItems="center"
+                                bg="transparent"
+                                border="none"
+                                p={0}
+                            >
+                                <FiStar fill={config?.[`_fav_${info.key}`] ? "currentColor" : "none"} />
+                            </Box>
+                            
+                            {/* 标签 */}
                             {info?.tags.map(item => (
                                 <Tag.Root key={item} colorPalette="purple" variant="subtle" size="sm">
                                     <Tag.Label>{item}</Tag.Label>
@@ -185,32 +236,32 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
                 </Flex>
             </Card.Header>
 
-<Collapsible.Root open={isExpanded}>
-    <Collapsible.Content>
-        <Card.Body pt={0} animation="fade-in 0.2s">
-            <Stack gap='4'>
-                {info?.description &&
-                    <Box bg="bg.subtle" p={3} borderRadius="lg" fontSize="sm" color="fg.muted">
-                        {info?.description}
-                    </Box>
-                }
-                {info?.description && info?.config_order.length != 0 && <Separator borderColor="border.subtle" />}
-                {info?.config_order.length != 0 &&
-                    <Box>
+            <Collapsible.Root open={isExpanded}>
+                <Collapsible.Content>
+                    <Card.Body pt={0} animation="fade-in 0.2s">
                         <Stack gap='4'>
-                            <Heading size='sm' color="fg.subtle">设置项</Heading>
-                            {
-                                info?.config_order.map((key) => (
-                                    <Config key={key} alias={alias} value={config[key]} info={info.config[key]} />
-                                ))
+                            {info?.description &&
+                                <Box bg="bg.subtle" p={3} borderRadius="lg" fontSize="sm" color="fg.muted">
+                                    {info?.description}
+                                </Box>
+                            }
+                            {info?.description && info?.config_order.length != 0 && <Separator borderColor="border.subtle" />}
+                            {info?.config_order.length != 0 &&
+                                <Box>
+                                    <Stack gap='4'>
+                                        <Heading size='sm' color="fg.subtle">设置项</Heading>
+                                        {
+                                            info?.config_order.map((key) => (
+                                                <Config key={key} alias={alias} value={config[key]} info={info.config[key]} />
+                                            ))
+                                        }
+                                    </Stack>
+                                </Box>
                             }
                         </Stack>
-                    </Box>
-                }
-            </Stack>
-                </Card.Body>
-    </Collapsible.Content>
-</Collapsible.Root>
+                    </Card.Body>
+                </Collapsible.Content>
+            </Collapsible.Root>
             {isDangerous && (
                 <Alert
                     isOpen={dangerConfirm.open}
@@ -223,4 +274,3 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
         </Card.Root >
     )
 }
-

--- a/src/components/Account/Module.tsx
+++ b/src/components/Account/Module.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Box, Button, Card, Flex, HStack, Heading, Separator, Stack, Tag, useDisclosure } from '@chakra-ui/react'
+import { Box, Button, Card, Collapsible, Flex, HStack, Heading, Separator, Stack, Tag, useDisclosure } from '@chakra-ui/react'
 import { ConfigValue, ModuleInfo } from '@interfaces/Module';
 import { FiChevronDown, FiCopy } from 'react-icons/fi';
 import { getAccountAreaSingleResultList, postAccountAreaSingle, putAccountConfig, getAccountConfig, putAccountConfigs } from '@api/Account';
@@ -185,30 +185,32 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
                 </Flex>
             </Card.Header>
 
-            {isExpanded && (
-                <Card.Body pt={0} animation="fade-in 0.2s">
-                    <Stack gap='4'>
-                        {info?.description &&
-                            <Box bg="bg.subtle" p={3} borderRadius="lg" fontSize="sm" color="fg.muted">
-                                {info?.description}
-                            </Box>
-                        }
-                        {info?.description && info?.config_order.length != 0 && <Separator borderColor="border.subtle" />}
-                        {info?.config_order.length != 0 &&
-                            <Box>
-                                <Stack gap='4'>
-                                    <Heading size='sm' color="fg.subtle">设置项</Heading>
-                                    {
-                                        info?.config_order.map((key) => (
-                                            <Config key={key} alias={alias} value={config[key]} info={info.config[key]} />
-                                        ))
-                                    }
-                                </Stack>
-                            </Box>
-                        }
-                    </Stack>
+<Collapsible.Root open={isExpanded}>
+    <Collapsible.Content>
+        <Card.Body pt={0} animation="fade-in 0.2s">
+            <Stack gap='4'>
+                {info?.description &&
+                    <Box bg="bg.subtle" p={3} borderRadius="lg" fontSize="sm" color="fg.muted">
+                        {info?.description}
+                    </Box>
+                }
+                {info?.description && info?.config_order.length != 0 && <Separator borderColor="border.subtle" />}
+                {info?.config_order.length != 0 &&
+                    <Box>
+                        <Stack gap='4'>
+                            <Heading size='sm' color="fg.subtle">设置项</Heading>
+                            {
+                                info?.config_order.map((key) => (
+                                    <Config key={key} alias={alias} value={config[key]} info={info.config[key]} />
+                                ))
+                            }
+                        </Stack>
+                    </Box>
+                }
+            </Stack>
                 </Card.Body>
-            )}
+    </Collapsible.Content>
+</Collapsible.Root>
             {isDangerous && (
                 <Alert
                     isOpen={dangerConfirm.open}

--- a/src/routes/daily/_sidebar/account/$account.tsx
+++ b/src/routes/daily/_sidebar/account/$account.tsx
@@ -1,13 +1,13 @@
-import { Box, Button, Tabs } from '@chakra-ui/react'
+import { Box, Button, Tabs } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { FiStar } from 'react-icons/fi';
 
-import { AccountResponse } from '@interfaces/Account'
-import Area from '@components/Account/Area'
+import { AccountResponse } from '@interfaces/Account';
+import Area from '@components/Account/Area';
 import ConfigImportExport from "@components/Account/ConfigImportExport.tsx";
-import Info from '@components/Account/Info'
-import { createFileRoute } from '@tanstack/react-router'
-import { getAccount } from '@api/Account'
+import Info from '@components/Account/Info';
+import { createFileRoute } from '@tanstack/react-router';
+import { getAccount } from '@api/Account';
 
 export const Route = createFileRoute('/daily/_sidebar/account/$account')({
     component: AccountComponent,
@@ -19,7 +19,14 @@ function AccountComponent() {
     const { account } = Route.useParams();
     const initialAccountInfo = Route.useLoaderData<AccountResponse>();
     const [accountInfo, setAccountInfo] = useState<AccountResponse>(initialAccountInfo);
-    const [showOnlyFav, setShowOnlyFav] = useState(false);
+
+    const initialTab = initialAccountInfo?.username !== '' && initialAccountInfo?.password !== '' ? "1" : "0";
+    
+    // activeTab 仅用于驱动 UI 按钮的高亮，点击瞬间 0ms 响应
+    const [activeTab, setActiveTab] = useState<string>(initialTab);
+
+    // 按 Tab 独立存储“只显示收藏”
+    const [favOnlyMap, setFavOnlyMap] = useState<Record<string, boolean>>({});
 
     const refreshAccountData = async () => {
         try {
@@ -34,11 +41,24 @@ function AccountComponent() {
         setAccountInfo(initialAccountInfo);
     }, [initialAccountInfo]);
 
+    const activeAreaIndex = Number(activeTab) - 1;
+    const currentArea = activeTab !== "0" && accountInfo?.area ? accountInfo.area[activeAreaIndex] : null;
+    const isCurrentTabFavOnly = currentArea ? !!favOnlyMap[currentArea.key] : false;
+
+    const handleToggleCurrentFavOnly = () => {
+        if (!currentArea?.key) return;
+        setFavOnlyMap(prev => ({
+            ...prev,
+            [currentArea.key]: !prev[currentArea.key]
+        }));
+    };
+
     return (
         <Tabs.Root 
             lazyMount 
             variant="plain" 
-            defaultValue={accountInfo?.username != '' && accountInfo?.password != '' ? "1" : "0"} 
+            value={activeTab}
+            onValueChange={(details) => setActiveTab(details.value)} // 0ms 同步高亮
             display={'flex'} 
             flexDirection={'column'} 
             height={'100%'}
@@ -53,7 +73,7 @@ function AccountComponent() {
                 mb={4}
                 overflowX="auto"
                 gap={1}
-                alignItems="center" // 确保垂直居中
+                alignItems="center"
             >
                 <Tabs.Trigger 
                     value="0"
@@ -61,13 +81,12 @@ function AccountComponent() {
                     py={1.5}
                     rounded="lg"
                     fontWeight="semibold"
-                    transition="all 0.2s"
-                     _selected={{ 
-                         bg: "blue.solid", 
-                         color: "white", 
-                         shadow: "md",
-                         _hover: { bg: "blue.600" } 
-                     }}
+                    transition="background-color 0.1s ease, color 0.1s ease"
+                    _selected={{ 
+                        bg: "blue.solid", 
+                        color: "white", 
+                        shadow: "md"
+                    }}
                     _hover={{ bg: "bg.subtle" }}
                 > 
                     {account} 
@@ -84,7 +103,7 @@ function AccountComponent() {
                         rounded="lg"
                         fontWeight="medium"
                         color="fg.muted"
-                        transition="all 0.2s"
+                        transition="background-color 0.1s ease, color 0.1s ease"
                         _selected={{ bg: "bg.subtle", color: "blue.600", fontWeight: "bold", shadow: "sm" }}
                         _hover={{ bg: "bg.subtle", color: "fg" }}
                     >
@@ -92,23 +111,24 @@ function AccountComponent() {
                     </Tabs.Trigger>
                 ))}
 
-                {/* 收藏按钮：放在 Tab 列表最右侧 */}
-                <Box display="flex" alignItems="center" pr={2}>
-                    <Button
-                        size="sm"
-                        variant={showOnlyFav ? "solid" : "ghost"}
-                        colorPalette={showOnlyFav ? "yellow" : "gray"}
-                        onClick={() => setShowOnlyFav(!showOnlyFav)}
-                        minW="120px"
-                        type="button"
-                    >
-                        {showOnlyFav ? (
-                            <><FiStar fill="currentColor" /> 显示全部</>
-                        ) : (
-                            <><FiStar /> 只显示收藏</>
-                        )}
-                    </Button>
-                </Box>
+                {activeTab !== "0" && (
+                    <Box display="flex" alignItems="center" pr={2}>
+                        <Button
+                            size="sm"
+                            variant={isCurrentTabFavOnly ? "solid" : "ghost"}
+                            colorPalette={isCurrentTabFavOnly ? "yellow" : "gray"}
+                            onClick={handleToggleCurrentFavOnly}
+                            minW="120px"
+                            type="button"
+                        >
+                            {isCurrentTabFavOnly ? (
+                                <><FiStar fill="currentColor" /> 显示全部</>
+                            ) : (
+                                <><FiStar /> 只显示收藏</>
+                            )}
+                        </Button>
+                    </Box>
+                )}
             </Tabs.List>
 
             <Box flex={1} overflow={'auto'}>
@@ -116,13 +136,15 @@ function AccountComponent() {
                     <Info accountInfo={accountInfo} onSaveSuccess={refreshAccountData} />
                     <ConfigImportExport alias={accountInfo?.alias} areas={accountInfo?.area} onImportSuccess={refreshAccountData} />
                 </Tabs.Content>
+
+                {/* 保持静态DOM挂载逻辑，由 Tabs.Root 统一做 lazyMount 缓存 */}
                 {accountInfo?.area.map((area, index) => (
                     <Tabs.Content value={String(index + 1)} key={area?.key}>
                         <Area 
                             alias={accountInfo?.alias} 
                             keys={area?.key} 
                             areaName={area?.name} 
-                            showOnlyFav={showOnlyFav}
+                            showOnlyFav={!!favOnlyMap[area?.key]} 
                         />
                     </Tabs.Content>
                 ))}

--- a/src/routes/daily/_sidebar/account/$account.tsx
+++ b/src/routes/daily/_sidebar/account/$account.tsx
@@ -1,5 +1,6 @@
-import { Box, Tabs } from '@chakra-ui/react'
+import { Box, Button, Tabs } from '@chakra-ui/react'
 import { useEffect, useState } from 'react';
+import { FiStar } from 'react-icons/fi';
 
 import { AccountResponse } from '@interfaces/Account'
 import Area from '@components/Account/Area'
@@ -7,20 +8,19 @@ import ConfigImportExport from "@components/Account/ConfigImportExport.tsx";
 import Info from '@components/Account/Info'
 import { createFileRoute } from '@tanstack/react-router'
 import { getAccount } from '@api/Account'
+
 export const Route = createFileRoute('/daily/_sidebar/account/$account')({
     component: AccountComponent,
     loader: ({ params: { account } }) => getAccount(account),
-    errorComponent: () => {
-        return <div> Not Found </div>
-    },
+    errorComponent: () => <div> Not Found </div>,
 })
 
 function AccountComponent() {
     const { account } = Route.useParams();
     const initialAccountInfo = Route.useLoaderData<AccountResponse>();
     const [accountInfo, setAccountInfo] = useState<AccountResponse>(initialAccountInfo);
+    const [showOnlyFav, setShowOnlyFav] = useState(false);
 
-    // 添加刷新数据的函数
     const refreshAccountData = async () => {
         try {
             const freshData = await getAccount(account);
@@ -30,7 +30,6 @@ function AccountComponent() {
         }
     };
 
-    // 初始化时设置数据
     useEffect(() => {
         setAccountInfo(initialAccountInfo);
     }, [initialAccountInfo]);
@@ -54,6 +53,7 @@ function AccountComponent() {
                 mb={4}
                 overflowX="auto"
                 gap={1}
+                alignItems="center" // 确保垂直居中
             >
                 <Tabs.Trigger 
                     value="0"
@@ -75,25 +75,42 @@ function AccountComponent() {
                 
                 <Box width="1px" height="16px" alignSelf="center" bg="border.muted" mx={1} />
 
-                {accountInfo?.area.map((area, index) => {
-                    return (
-                        <Tabs.Trigger 
-                            value={String(index + 1)} 
-                            key={area?.key}
-                            px={3}
-                            py={1.5}
-                            rounded="lg"
-                            fontWeight="medium"
-                            color="fg.muted"
-                            transition="all 0.2s"
-                            _selected={{ bg: "bg.subtle", color: "blue.600", fontWeight: "bold", shadow: "sm" }}
-                            _hover={{ bg: "bg.subtle", color: "fg" }}
-                        >
-                            {area?.name}
-                        </Tabs.Trigger>
-                    );
-                })}
+                {accountInfo?.area.map((area, index) => (
+                    <Tabs.Trigger 
+                        value={String(index + 1)} 
+                        key={area?.key}
+                        px={3}
+                        py={1.5}
+                        rounded="lg"
+                        fontWeight="medium"
+                        color="fg.muted"
+                        transition="all 0.2s"
+                        _selected={{ bg: "bg.subtle", color: "blue.600", fontWeight: "bold", shadow: "sm" }}
+                        _hover={{ bg: "bg.subtle", color: "fg" }}
+                    >
+                        {area?.name}
+                    </Tabs.Trigger>
+                ))}
+
+                {/* 收藏按钮：放在 Tab 列表最右侧 */}
+                <Box display="flex" alignItems="center" pr={2}>
+                    <Button
+                        size="sm"
+                        variant={showOnlyFav ? "solid" : "ghost"}
+                        colorPalette={showOnlyFav ? "yellow" : "gray"}
+                        onClick={() => setShowOnlyFav(!showOnlyFav)}
+                        minW="120px"
+                        type="button"
+                    >
+                        {showOnlyFav ? (
+                            <><FiStar fill="currentColor" /> 显示全部</>
+                        ) : (
+                            <><FiStar /> 只显示收藏</>
+                        )}
+                    </Button>
+                </Box>
             </Tabs.List>
+
             <Box flex={1} overflow={'auto'}>
                 <Tabs.Content value="0">
                     <Info accountInfo={accountInfo} onSaveSuccess={refreshAccountData} />
@@ -101,8 +118,12 @@ function AccountComponent() {
                 </Tabs.Content>
                 {accountInfo?.area.map((area, index) => (
                     <Tabs.Content value={String(index + 1)} key={area?.key}>
-                        {' '}
-                        <Area alias={accountInfo?.alias} keys={area?.key} areaName={area?.name} />{' '}
+                        <Area 
+                            alias={accountInfo?.alias} 
+                            keys={area?.key} 
+                            areaName={area?.name} 
+                            showOnlyFav={showOnlyFav}
+                        />
                     </Tabs.Content>
                 ))}
             </Box>


### PR DESCRIPTION
## Summary

本次提交修复了多个界面 Bug，新增模块收藏系统，优化了 Tab 切换体验和配置导入导出逻辑。

## 改动文件

- **routes/daily/_sidebar/account/$account.tsx**
- **components/Account/Area.tsx**
- **components/Account/Module.tsx**
- **components/Account/ConfigImportExport.tsx**

## 修复的问题

### 折叠菜单状态丢失
原代码使用 `{isExpanded && <Card.Body>}` 条件渲染，折叠时会卸载子组件，重新展开后内部非受控组件 (`defaultValue`) 状态被重置。  
**修复**：改用 `Collapsible.Root` 组件，并设置 `unmountOnExit={false}`，使内容仅隐藏而不销毁，保留配置状态。

### Checkbox 导入/同步后状态不更新
使用了 `defaultChecked`，导致父组件 `config` 变化后界面不响应。  
**修复**：改为受控属性 `checked={!!config[info.key]}`，并通过 `onConfigUpdate` 回调同步父组件 state。同时增加**乐观更新**：点击立即更新 UI，请求失败则回滚。

### TOC 目录生成崩溃
误将 `config?.order.map` 当作 `forEach` 使用，且未防御 `config.info[module]` 缺失导致的页面白屏。  
**修复**：基于 `visibleModules` 生成目录，使用可选链 `config?.info?.[moduleKey]?.name` 安全取值。

### 导入时校验数据被覆盖
`realImportByModule` 的校验结果被后续 `for...in` 循环无条件覆盖，且模块开关值为 `false` 时被错误跳过。  
**修复**：优先保留校验后的值，仅补充未覆盖的非收藏字段；将开关值检查从 `if (configs[moduleKey] && ...)` 改为 `if (configs[moduleKey] !== undefined && ...)`。

### `single` 类型校验逻辑错误
原代码 `case 'single'` 只允许 `boolean`，导致所有正常单选值（`string` / `number`）在导入时被丢弃。  
**修复**：改为允许 `string | number`，避免配置丢失。

### 导入损坏文件报错不明确
直接 `atob` / `JSON.parse` 崩溃无提示。  
**修复**：增加 try‑catch，抛出 “配置文件格式无效” 等明确错误信息。

## 新增功能

### 模块收藏系统
- 每个模块名称右侧新增星标按钮（`FiStar`），点击切换收藏，颜色即时响应
- 收藏状态持久化在 `localStorage`（key: `autopcr_fav_{alias}`）
- **Area** 组件支持 `showOnlyFav` 过滤属性，仅展示已收藏模块
- **账号页顶部 Tab 栏右侧新增 “只显示收藏” 按钮**，按 Tab 独立记忆过滤状态
- **导入/导出**时自动附带/恢复收藏标记，保证收藏信息随配置迁移

####该功能主要目的：在多个模块中，让用户可以自行定义什么功能是随时需要调用的，让其可以以最快速度，在不同的时期做出不同的设置，以及让它变得更加趁手。

以下为效果图：
<img width="1643" height="1546" alt="image" src="https://github.com/user-attachments/assets/9553a11a-78b0-4462-b207-bdec59cb6dd2" />

<img width="1672" height="1359" alt="image" src="https://github.com/user-attachments/assets/97125233-6c2c-4637-9a37-4d80733faa18" />


### 乐观更新
点击 Checkbox 后界面立即反馈，无需等待后端；请求失败则自动回滚。

### 切换 Tab / 区域的无感过渡
- 切换 area 时不再出现白屏或骨架闪烁，旧内容保留并降低不透明度，数据就绪后平滑恢复
- 仅在首次完全无数据时展示骨架屏

## 技术细节
- **状态管理**：Area 组件用 `isFetching` 标志控制 opacity，`$account.tsx` 用 `activeTab` 同步 Tab 高亮
- **收藏存储**：`autopcr_fav_{alias}` → `Record<areaKey, string[]>`
- **Checkbox 受控**：`checked={!!config[info.key]}`，通过 `onConfigUpdate` 向上更新，失败回滚
- **导入校验增强**：`toCheckedConfigItem` 对 `single` / `multi` 等类型做了更精准的类型守卫
- **导出合并**：导出前读取 localStorage 收藏数据，以 `_fav_` 前缀混入配置 JSON；导入时解析并回写

## 测试建议

### 折叠菜单
- 修改任意模块的设置项 → 折叠 → 展开，确认值未重置
- 切换账号或刷新页面后，设置保持

### Checkbox 受控与回滚
- 点击模块开关，界面立即变化
- 模拟网络失败（如停止后端），验证开关回滚并提示错误

### 收藏功能
- 点击星标，颜色即时变化
- 刷新页面，收藏状态持久
- 开启 “只显示收藏”，页面与目录仅展示收藏模块
- 切换 Tab 后返回，过滤状态独立保留
- 导出配置 → 清除 localStorage → 导入，收藏恢复

### 导入导出
- 导出文件，检查 `_fav_` 字段
- 导入含 `false` 开关的配置，确认模块关闭
- 导入损坏或非 `.autopcrcfg` 文件，弹出明确错误提示

### Tab 切换体验
- 快速切换 area，无白屏或闪烁，旧内容半透明平滑过渡
- 首次进入页面（无缓存），骨架屏正常显示