### PR TITLE
优化账号一览/详情体验：显示名、进详情、清理状态徽章、配置保存与长列表搜索

### DIFF
--- a/src/components/Account/Area.tsx
+++ b/src/components/Account/Area.tsx
@@ -33,7 +33,6 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
 
     useEffect(() => {
         let isMounted = true;
-        setState({ config: null, isLoading: true });
 
         if (alias && key) {
             getAccountConfig(alias, key)
@@ -109,7 +108,6 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
         <>
             <Box pb={20} position="relative">
                 <Stack gap={4}>
-                    {/* 首次加载未获取到数据时：只显示灰色骨架块，避免任何白屏 */}
                     {state.isLoading && !config ? (
                         Array.from({ length: 4 }).map((_, i) => (
                             <Box key={i} p={6} borderWidth="1px" borderRadius="2xl" bg="bg.panel" shadow="sm">
@@ -155,7 +153,7 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
                 zIndex={100}
             >
                 <Popover.Root lazyMount positioning={{ placement: 'left', gutter: 4 }}>
-                    <Popover.Trigger>
+                    <Popover.Trigger asChild>
                         <IconButton
                             aria-label="TOC"
                             colorPalette="blue"

--- a/src/components/Account/Config.tsx
+++ b/src/components/Account/Config.tsx
@@ -1,7 +1,16 @@
-import { Box, Button, Checkbox as ChakraCheckbox, Input, NativeSelect, Stack, Text, Textarea } from '@chakra-ui/react';
+import {
+    Box,
+    Button,
+    Checkbox as ChakraCheckbox,
+    Flex,
+    Input,
+    NativeSelect,
+    Stack,
+    Text,
+    Textarea,
+} from '@chakra-ui/react';
 import { AxiosError } from 'axios';
 import NiceModal from '@ebay/nice-modal-react';
-import type * as React from 'react';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { putAccountConfig } from '@/api/Account';
 import { ConfigInfo, ConfigValue } from '@/interfaces/Module';
@@ -11,6 +20,7 @@ import { NumberInput, NumberInputField } from '../../components/ui/number-input'
 import { Switch } from '../../components/ui/switch';
 import { toaster } from '../../components/ui/toaster';
 import multiSelectModal from './MultiSelectModal';
+import singleSelectModal from './SingleSelectModal';
 
 interface ConfigProps {
     alias: string;
@@ -18,16 +28,29 @@ interface ConfigProps {
     info: ConfigInfo;
 }
 
-/**
- * 通用受控配置 Hook
- * - 管理本地 state，外部 value 变化时自动同步
- * - 提供 save 方法，带乐观更新 + 失败回滚 + 卸载保护
- */
+const configSaveChains = new Map<string, Promise<unknown>>();
+
+export function enqueueConfigSave<T>(alias: string, task: () => Promise<T>): Promise<T> {
+    const prev = configSaveChains.get(alias) || Promise.resolve();
+    const next = prev.catch(() => undefined).then(task);
+    configSaveChains.set(
+        alias,
+        next.then(
+            () => undefined,
+            () => undefined,
+        ),
+    );
+    return next;
+}
+
+const ROW_H = '2.25rem';
+const SINGLE_SEARCH_THRESHOLD = 30;
+
 function useConfigState<T>(
     alias: string,
     key: string,
     propValue: T,
-    transform?: (val: T) => ConfigValue
+    transform?: (val: T) => ConfigValue,
 ) {
     const [state, setState] = useState<T>(propValue);
     const mountedRef = useRef(true);
@@ -47,7 +70,7 @@ function useConfigState<T>(
         setState(newValue);
         const payload = transform ? transform(newValue) : (newValue as ConfigValue);
         try {
-            const res = await putAccountConfig(alias, key, payload);
+            const res = await enqueueConfigSave(alias, () => putAccountConfig(alias, key, payload));
             if (mountedRef.current) {
                 toaster.create({ type: 'success', title: '保存成功', description: res });
             }
@@ -58,7 +81,7 @@ function useConfigState<T>(
                 toaster.create({
                     type: 'error',
                     title: '保存失败',
-                    description: axiosErr.response?.data as string || '网络错误',
+                    description: (axiosErr.response?.data as string) || '网络错误',
                 });
             }
         }
@@ -67,35 +90,34 @@ function useConfigState<T>(
     return [state, setState, save] as const;
 }
 
-// ---------- ConfigBool ----------
 function ConfigBool({ alias, value, info }: ConfigProps) {
     const [checked, , save] = useConfigState(alias, info.key, value as boolean);
 
     return (
         <InputGroup
+            w="full"
+            minH={ROW_H}
+            alignItems="center"
             startElement={info.desc}
             endElement={
                 <Switch
                     id={info.key}
+                    size="md"
                     checked={checked}
-                    onCheckedChange={(d) => save(d.checked)}
+                    onCheckedChange={(d) => save(!!d.checked)}
                 />
             }
         />
     );
 }
 
-// ---------- ConfigInt（改为 onBlur 保存）----------
 function ConfigInt({ alias, value, info }: ConfigProps) {
     const min = Math.min(...(info.candidates.map((c) => c.value) as number[]));
     const max = Math.max(...(info.candidates.map((c) => c.value) as number[]));
 
-    // 受控的字符串显示值
     const [numStr, setNumStr] = useState(String(value));
-    //const [saving, setSaving] = useState(false); // 可选 loading 态
     const mountedRef = useRef(true);
 
-    // 外部 value 同步
     useEffect(() => {
         setNumStr(String(value));
     }, [value]);
@@ -107,25 +129,18 @@ function ConfigInt({ alias, value, info }: ConfigProps) {
         };
     }, []);
 
-    // 处理失焦保存
     const handleBlur = () => {
-        let finalValue: string | number;
-
-        // 空值或无效值处理为最小值
+        let finalValue: number;
         if (numStr === '' || isNaN(Number(numStr))) {
             finalValue = min;
-            setNumStr(String(min)); // UI 也回显最小值
         } else {
             finalValue = Number(numStr);
         }
-
-        // 边界检查（可选，但保留原有行为）
         if (finalValue < min) finalValue = min;
         if (finalValue > max) finalValue = max;
+        setNumStr(String(finalValue));
 
-        // 发送保存
-        const payload: ConfigValue = finalValue as ConfigValue;
-        putAccountConfig(alias, info.key, payload)
+        enqueueConfigSave(alias, () => putAccountConfig(alias, info.key, finalValue as ConfigValue))
             .then((res) => {
                 if (mountedRef.current) {
                     toaster.create({ type: 'success', title: '保存成功', description: res });
@@ -133,53 +148,158 @@ function ConfigInt({ alias, value, info }: ConfigProps) {
             })
             .catch((err: AxiosError) => {
                 if (mountedRef.current) {
-                    // 失败回滚到外部 value
                     setNumStr(String(value));
                     toaster.create({
                         type: 'error',
                         title: '保存失败',
-                        description: err.response?.data as string || '网络错误',
+                        description: (err.response?.data as string) || '网络错误',
                     });
                 }
             });
     };
 
-    // 输入过程中仅更新本地状态
-    const handleChange = (e: { value: string }) => {
-        setNumStr(e.value);
-    };
-
     return (
-        <InputGroup startElement={info.desc}>
-            <NumberInput
-                value={numStr}
-                onValueChange={handleChange}
-                id={info.key}
-                min={min}
-                max={max}
+        <InputGroup w="full" minH={ROW_H} alignItems="center" startElement={info.desc}>
+            <Box
+                w="18%"
+                h={ROW_H}
+                maxH={ROW_H}
+                display="flex"
+                alignItems="center"
+                css={{
+                    '& [data-part="root"]': {
+                        height: ROW_H,
+                        maxHeight: ROW_H,
+                        width: '100%',
+                    },
+                    '& [data-part="input"]': {
+                        height: ROW_H,
+                        minHeight: ROW_H,
+                        maxHeight: ROW_H,
+                        py: 0,
+                    },
+                    '& [data-part="control"]': {
+                        height: ROW_H,
+                        maxHeight: ROW_H,
+                        display: 'flex',
+                        flexDirection: 'column',
+                    },
+                    '& [data-part="increment-trigger"], & [data-part="decrement-trigger"]': {
+                        height: '1.125rem',
+                        minHeight: '1.125rem',
+                        maxHeight: '1.125rem',
+                        flex: 1,
+                    },
+                }}
             >
-                <NumberInputField onBlur={handleBlur} />
-            </NumberInput>
+                <NumberInput
+                    value={numStr}
+                    onValueChange={(e) => setNumStr(e.value)}
+                    id={info.key}
+                    min={min}
+                    max={max}
+                    size="sm"
+                    w="full"
+                    h={ROW_H}
+                    maxH={ROW_H}
+                >
+                    <NumberInputField h={ROW_H} minH={ROW_H} maxH={ROW_H} py={0} onBlur={handleBlur} />
+                </NumberInput>
+            </Box>
         </InputGroup>
     );
 }
 
-// ---------- ConfigSingle ----------
+function ConfigSingleSearch({ alias, value, info }: ConfigProps) {
+    const [localValue, setLocalValue] = useState<ConfigValue>(value);
+    const mountedRef = useRef(true);
+
+    useEffect(() => {
+        setLocalValue(value);
+    }, [value]);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
+
+    const displayText = (() => {
+        const unit = info.candidates.find((u) => u.value === localValue);
+        if (!unit) {
+            return localValue === undefined || localValue === null || localValue === ''
+                ? ''
+                : String(localValue);
+        }
+        return unit.nickname ? unit.nickname : unit.display;
+    })();
+
+    const handleClick = async (e: React.MouseEvent) => {
+        e.stopPropagation();
+        const previousValue = localValue;
+        try {
+            const ret = (await NiceModal.show(singleSelectModal, {
+                candidates: info.candidates,
+                value: localValue,
+            })) as ConfigValue | undefined;
+            if (ret === undefined) return;
+
+            const res = await enqueueConfigSave(alias, () => putAccountConfig(alias, info.key, ret));
+            if (mountedRef.current) {
+                setLocalValue(ret);
+                toaster.create({ type: 'success', title: '保存成功', description: res });
+            }
+        } catch (err) {
+            const axiosErr = err as AxiosError;
+            if (mountedRef.current) {
+                setLocalValue(previousValue);
+                toaster.create({
+                    type: 'error',
+                    title: '保存失败',
+                    description: (axiosErr.response?.data as string) || '网络错误',
+                });
+            }
+        }
+    };
+
+    return (
+        <InputGroup
+            w="1/3"
+            minH={ROW_H}
+            alignItems="center"
+            startElement={info.desc}
+            endElement={
+                <Button size="sm" h={ROW_H} onClick={handleClick}>
+                    选择
+                </Button>
+            }
+        >
+            <Input h={ROW_H} value={displayText} readOnly onClick={handleClick} cursor="pointer" />
+        </InputGroup>
+    );
+}
+
 function ConfigSingle({ alias, value, info }: ConfigProps) {
+    if ((info.candidates?.length || 0) >= SINGLE_SEARCH_THRESHOLD) {
+        return <ConfigSingleSearch alias={alias} value={value} info={info} />;
+    }
+
     const [selectValue, , save] = useConfigState(alias, info.key, value as string | number);
 
     return (
-        <InputGroup startElement={info.desc}>
-            <NativeSelect.Root>
+        <InputGroup w="1/4" minH={ROW_H} alignItems="center" startElement={info.desc}>
+            <NativeSelect.Root size="sm" w="full" flex="1">
                 <NativeSelect.Field
+                    h={ROW_H}
+                    id={info.key}
+                    value={selectValue}
                     onChange={(e) => {
                         let newValue: ConfigValue = e.target.value;
                         const intVal = Number(newValue);
                         if (!isNaN(intVal)) newValue = intVal;
-                        save(newValue);
+                        void save(newValue);
                     }}
-                    id={info.key}
-                    value={selectValue}
                 >
                     {info.candidates.map((element) => (
                         <option
@@ -195,11 +315,11 @@ function ConfigSingle({ alias, value, info }: ConfigProps) {
     );
 }
 
-// ---------- ConfigMulti ----------
 function ConfigMulti({ alias, value, info }: ConfigProps) {
     const initialStrArr = useMemo(
         () => (value as (string | number)[]).map(String),
-        [JSON.stringify(value)]
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [JSON.stringify(value)],
     );
 
     const [groupValue, setGroupValue] = useState(initialStrArr);
@@ -211,7 +331,9 @@ function ConfigMulti({ alias, value, info }: ConfigProps) {
 
     useEffect(() => {
         mountedRef.current = true;
-        return () => { mountedRef.current = false; };
+        return () => {
+            mountedRef.current = false;
+        };
     }, []);
 
     const handleSave = (newStrArr: string[]) => {
@@ -220,10 +342,11 @@ function ConfigMulti({ alias, value, info }: ConfigProps) {
         if (intArr.length > 0 && !isNaN(intArr[0])) postValue = intArr;
 
         setGroupValue(newStrArr);
-        putAccountConfig(alias, info.key, postValue)
+        enqueueConfigSave(alias, () => putAccountConfig(alias, info.key, postValue))
             .then((res) => {
-                if (mountedRef.current)
+                if (mountedRef.current) {
                     toaster.create({ type: 'success', title: '保存成功', description: res });
+                }
             })
             .catch((err: AxiosError) => {
                 if (mountedRef.current) {
@@ -231,73 +354,79 @@ function ConfigMulti({ alias, value, info }: ConfigProps) {
                     toaster.create({
                         type: 'error',
                         title: '保存失败',
-                        description: err.response?.data as string || '网络错误',
+                        description: (err.response?.data as string) || '网络错误',
                     });
                 }
             });
     };
 
-    const onCheckboxChange = (param: string[] | { value: string[] }) => {
-        const newValue = Array.isArray(param) ? param : param.value;
-        handleSave(newValue);
-    };
-
     return (
-        <InputGroup startElement={info.desc}>
-            <Box
-                paddingLeft="16px"
-                paddingRight="32px"
-                overflowY="scroll"
-                borderWidth="1px"
-                borderColor="border.subtle"
-                borderRadius="md"
+        <InputGroup w="full" minH={ROW_H} alignItems="center" startElement={info.desc}>
+            <ChakraCheckbox.Group
+                value={groupValue}
                 w="full"
+                px={2}
+                onValueChange={(param: string[] | { value: string[] }) => {
+                    const newValue = Array.isArray(param) ? param : param.value;
+                    handleSave(newValue);
+                }}
             >
-                <ChakraCheckbox.Group onValueChange={onCheckboxChange} value={groupValue}>
-                    <Stack gap={[1, 5]} direction={['column', 'row']}>
-                        {info.candidates.map((element) => (
-                            <Checkbox
-                                key={element.value as string | number}
-                                value={String(element.value)}
-                            >
-                                {element.display}
-                            </Checkbox>
-                        ))}
-                    </Stack>
-                </ChakraCheckbox.Group>
-            </Box>
+                <Flex flexWrap="wrap" gap={3} align="center" w="full" py={1}>
+                    {info.candidates.map((element) => (
+                        <Checkbox
+                            key={element.value as string | number}
+                            value={String(element.value)}
+                        >
+                            {element.display}
+                        </Checkbox>
+                    ))}
+                </Flex>
+            </ChakraCheckbox.Group>
         </InputGroup>
     );
 }
 
-// ---------- ConfigTime ----------
 function ConfigTime({ alias, value, info }: ConfigProps) {
     const [timeStr, setTimeStr] = useState(value as string);
+    const mountedRef = useRef(true);
 
     useEffect(() => {
         setTimeStr(value as string);
     }, [value]);
 
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
+
     const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
         const newValue = e.target.value;
-        putAccountConfig(alias, info.key, newValue as ConfigValue)
+        enqueueConfigSave(alias, () => putAccountConfig(alias, info.key, newValue as ConfigValue))
             .then((res) => {
-                toaster.create({ type: 'success', title: '保存成功', description: res });
+                if (mountedRef.current) {
+                    toaster.create({ type: 'success', title: '保存成功', description: res });
+                }
             })
             .catch((err: AxiosError) => {
-                setTimeStr(value as string);
-                toaster.create({
-                    type: 'error',
-                    title: '保存失败',
-                    description: err.response?.data as string || '网络错误',
-                });
+                if (mountedRef.current) {
+                    setTimeStr(value as string);
+                    toaster.create({
+                        type: 'error',
+                        title: '保存失败',
+                        description: (err.response?.data as string) || '网络错误',
+                    });
+                }
             });
     };
 
     return (
-        <InputGroup startElement={info.desc}>
+        <InputGroup w="min" minH={ROW_H} alignItems="center" startElement={info.desc}>
             <Input
                 type="time"
+                h={ROW_H}
+                size="sm"
                 value={timeStr}
                 onChange={(e) => setTimeStr(e.target.value)}
                 onBlur={handleBlur}
@@ -307,14 +436,21 @@ function ConfigTime({ alias, value, info }: ConfigProps) {
     );
 }
 
-// ---------- ConfigText ----------
 function ConfigText({ alias, value, info }: ConfigProps) {
     const [textStr, setTextStr] = useState(value as string);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const mountedRef = useRef(true);
 
     useEffect(() => {
         setTextStr(value as string);
     }, [value]);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
 
     useLayoutEffect(() => {
         const el = textareaRef.current;
@@ -326,35 +462,41 @@ function ConfigText({ alias, value, info }: ConfigProps) {
 
     const handleBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
         const newValue = e.target.value;
-        putAccountConfig(alias, info.key, newValue as ConfigValue)
+        enqueueConfigSave(alias, () => putAccountConfig(alias, info.key, newValue as ConfigValue))
             .then((res) => {
-                toaster.create({ type: 'success', title: '保存成功', description: res });
+                if (mountedRef.current) {
+                    toaster.create({ type: 'success', title: '保存成功', description: res });
+                }
             })
             .catch((err: AxiosError) => {
-                setTextStr(value as string);
-                toaster.create({
-                    type: 'error',
-                    title: '保存失败',
-                    description: err.response?.data as string || '网络错误',
-                });
+                if (mountedRef.current) {
+                    setTextStr(value as string);
+                    toaster.create({
+                        type: 'error',
+                        title: '保存失败',
+                        description: (err.response?.data as string) || '网络错误',
+                    });
+                }
             });
     };
 
     return (
-        <>
-            <Text>{info.desc}</Text>
+        <Stack gap={1} w="full">
+            <Text fontSize="sm" color="fg.muted">
+                {info.desc}
+            </Text>
             <Textarea
                 ref={textareaRef}
                 value={textStr}
                 onChange={(e) => setTextStr(e.target.value)}
                 onBlur={handleBlur}
                 id={info.key}
+                minH={ROW_H}
             />
-        </>
+        </Stack>
     );
 }
 
-// ---------- ConfigMultiSearch ----------
 function ConfigMultiSearch({ alias, value, info }: ConfigProps) {
     const [localValue, setLocalValue] = useState<ConfigValue>(value);
     const mountedRef = useRef(true);
@@ -365,11 +507,13 @@ function ConfigMultiSearch({ alias, value, info }: ConfigProps) {
 
     useEffect(() => {
         mountedRef.current = true;
-        return () => { mountedRef.current = false; };
+        return () => {
+            mountedRef.current = false;
+        };
     }, []);
 
     const displayValue = ((localValue || []) as number[]).map((id) => {
-        const unit = info.candidates.find((unit) => unit.value === id);
+        const unit = info.candidates.find((u) => u.value === id);
         return unit ? (unit.nickname ? unit.nickname : unit.display) : String(id);
     });
 
@@ -383,7 +527,7 @@ function ConfigMultiSearch({ alias, value, info }: ConfigProps) {
             })) as ConfigValue;
             if (ret === undefined) return;
 
-            const res = await putAccountConfig(alias, info.key, ret);
+            const res = await enqueueConfigSave(alias, () => putAccountConfig(alias, info.key, ret));
             if (mountedRef.current) {
                 setLocalValue(ret);
                 toaster.create({ type: 'success', title: '保存成功', description: res });
@@ -396,7 +540,7 @@ function ConfigMultiSearch({ alias, value, info }: ConfigProps) {
                 toaster.create({
                     type: 'error',
                     title: '保存失败',
-                    description: axiosErr.response?.data as string || '网络错误',
+                    description: (axiosErr.response?.data as string) || '网络错误',
                 });
             }
         }
@@ -404,19 +548,27 @@ function ConfigMultiSearch({ alias, value, info }: ConfigProps) {
 
     return (
         <InputGroup
+            w="1/3"
+            minH={ROW_H}
+            alignItems="center"
             startElement={info.desc}
             endElement={
-                <Button size="sm" onClick={handleClick}>
+                <Button size="sm" h={ROW_H} onClick={handleClick}>
                     选择
                 </Button>
             }
         >
-            <Input value={displayValue.join(', ')} readOnly onClick={handleClick} cursor="pointer" />
+            <Input
+                h={ROW_H}
+                value={displayValue.join(', ')}
+                readOnly
+                onClick={handleClick}
+                cursor="pointer"
+            />
         </InputGroup>
     );
 }
 
-// ---------- 主组件 ----------
 export default function Config({ alias, value, info }: ConfigProps) {
     switch (info?.config_type) {
         case 'bool':

--- a/src/components/Account/ConfigImportExport.tsx
+++ b/src/components/Account/ConfigImportExport.tsx
@@ -54,7 +54,10 @@ const ConfigImportExport = ({ alias, areas, onImportSuccess }: ConfigIOProps) =>
             
             const strCfg = btoa(encodeURIComponent(JSON.stringify(allConfig)));
             const blob = new Blob([strCfg], { type: 'text/plain;charset=utf-8' });
-            saveAs(blob, `autopcr_${alias}.autopcrcfg`);
+            const storedName = localStorage.getItem(`autopcr_displayName_${alias}`);
+            const rawName = (storedName && storedName.trim()) ? storedName.trim() : alias;
+            const safeName = rawName.replace(/[\\/:*?"<>|]/g, '_');
+            saveAs(blob, `autopcr_${safeName}.autopcrcfg`);
             toaster.create({ type: "success", title: "配置导出成功", description: "配置文件下载可能会有延迟，请稍后..." });
         }).catch((err: Error) => {
             toaster.create({ type: 'error', title: '配置保存失败', description: err.message });

--- a/src/components/Account/ConfigImportExport.tsx
+++ b/src/components/Account/ConfigImportExport.tsx
@@ -13,7 +13,7 @@ import {getAccountConfig, putAccountConfigs} from "@api/Account.ts";
 import {AreaInfo} from "@interfaces/Account.ts";
 import {AxiosError} from "axios";
 import {saveAs} from "file-saver";
-import { toaster } from "../../components/ui/toaster";
+import { toaster } from "@components/ui/toaster";
 
 interface ConfigIOProps {
     alias: string;
@@ -66,8 +66,10 @@ const ConfigImportExport = ({ alias, areas, onImportSuccess }: ConfigIOProps) =>
     const toCheckedConfigItem = (type: ConfigType, candidates: Candidate[], value: unknown): ConfigValue | undefined => {
         switch (type) {
             case 'bool':
+                if (typeof value === "boolean") return value;
+                break;
             case 'single':
-                if (typeof value === "string" || typeof value === "number" || typeof value === "bool") return value;
+                if (typeof value === "string" || typeof value === "number") return value;
                 break
             case 'int':
                 if (typeof value === "number") return value;

--- a/src/components/Account/DashBoard.tsx
+++ b/src/components/Account/DashBoard.tsx
@@ -13,19 +13,18 @@ import {
     Tag,
     Text,
 } from '@chakra-ui/react';
-import { FiActivity, FiBook, FiCheck, FiCopy, FiGrid, FiKey, FiLayers, FiList, FiSettings, FiStar, FiTarget, FiUpload, FiUserMinus, FiUserPlus, FiUserX } from 'react-icons/fi';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { FiActivity, FiBook, FiCheck, FiCopy, FiGrid, FiKey, FiLayers, FiList, FiStar, FiTarget, FiUpload, FiUserMinus, FiUserPlus, FiUserX, FiX } from 'react-icons/fi';
 import { Radio, RadioGroup } from '../../components/ui/radio';
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useMemo, useRef } from 'react';
 import { Skeleton, SkeletonText } from '../../components/ui/skeleton';
 import { clearAccounts, deleteAccount, getAccountDailyResultList, getUserInfo, putUserInfo } from '@api/Account';
-import { delAccount, postAccount, postAccountAreaDaily, postAccountImport } from '@api/Account';
+import { delAccount, getAccount, getAccountConfig, postAccount, postAccountAreaDaily, postAccountImport, putAccountConfigs } from '@api/Account';
 import { useEffect, useState } from 'react';
+import { Link, useNavigate } from '@tanstack/react-router';
 
 import Alert from '../alert';
 import { AxiosError } from 'axios';
 import { Checkbox } from '../../components/ui/checkbox';
-import { CloseButton } from '../../components/ui/close-button';
 import { Route as DashBoardRoute } from '@routes/daily/_sidebar/account/index';
 import { IconButton } from '../../components/ui/icon-button';
 import { Route as LoginRoute } from '@routes/daily/login';
@@ -38,8 +37,26 @@ import { toaster } from '../../components/ui/toaster';
 import { useCountHook } from '../count';
 import { useDisclosure } from '@chakra-ui/react';
 import ConfigSyncModal from './ConfigSyncModal';
+import type { Candidate, ConfigType, ConfigValue, ModuleResponse } from '@interfaces/Module';
 
 const handle: Map<string, (arg0: boolean) => void> = new Map<string, (arg0: boolean) => void>();
+
+const DISPLAY_NAME_KEY = (alias: string) => `autopcr_displayName_${alias}`;
+
+function getDisplayName(alias: string): string {
+    return localStorage.getItem(DISPLAY_NAME_KEY(alias)) || alias;
+}
+
+/** 收集其他账号已占用的显示名（含未自定义时的原始 alias） */
+function collectOccupiedNames(accounts: AccountInfoInterface[] | undefined, selfAlias: string): Set<string> {
+    const set = new Set<string>();
+    for (const acc of accounts || []) {
+        if (acc.name === selfAlias) continue;
+        set.add(getDisplayName(acc.name));
+        set.add(acc.name);
+    }
+    return set;
+}
 
 export function DashBoard() {
     const [userInfo, setUserInfo] = useState<UserInfoResponse>();
@@ -54,8 +71,14 @@ export function DashBoard() {
         return savedView ? savedView === 'table' : false;
     });
     const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
-    
-    // Status colors can remain as functional colors
+
+    useEffect(() => {
+        if (sessionStorage.getItem('autopcr_need_refresh_dashboard') === '1') {
+            sessionStorage.removeItem('autopcr_need_refresh_dashboard');
+            freshAccountInfo.onToggle();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const showReadme = () => {
         NiceModal.show(ReadmeModal, {})
@@ -136,13 +159,11 @@ export function DashBoard() {
 
     const handleCleanDailyAll = () => {
         if (isTableView && selectedAccounts.length > 0) {
-            // 清理选中的账号
             for (const accountName of selectedAccounts) {
                 const fn = handle.get(accountName);
                 if (fn) fn(false);
             }
         } else {
-            // 清理所有账号
             for (const fn of handle.values()) {
                 fn(false);
             }
@@ -169,7 +190,6 @@ export function DashBoard() {
 
     const handleCreateAccount = () => {
         if (creatAccountSwitch.open) {
-            // 检查alias是否为空
             if (!alias || alias.trim() === '') {
                 toaster.create({
                     type: 'error',
@@ -187,7 +207,7 @@ export function DashBoard() {
                         description: res,
                     });
                     creatAccountSwitch.onToggle();
-                    setAlias(''); // 重置输入框
+                    setAlias('');
                     freshAccountInfo.onToggle();
                 })
                 .catch((err: AxiosError) => {
@@ -246,16 +266,23 @@ export function DashBoard() {
 
     const fileInputRef = React.useRef<HTMLInputElement>(null);
 
+    const occupiedNamesFactory = useMemo(() => {
+        return (selfAlias: string) => collectOccupiedNames(userInfo?.accounts, selfAlias);
+    }, [userInfo?.accounts]);
+
     return (
         <Stack gap={4} h="full" w="full" p={4} position="relative" zIndex={1}>
-            {/* Dashboard Header - Minimalist */}
             <Card.Root variant="elevated" bg="bg.glass" backdropFilter="blur(12px)" shadow="sm" borderRadius="2xl" borderWidth="1px" borderColor="border.subtle">
                 <Card.Body py={2} px={4}>
                     <Flex justify="space-between" align="center" wrap="wrap" gap={2}>
                         <Box>
-                            <Text fontSize="md" fontWeight="bold">
-                                {!userInfo ? <Skeleton height="20px" width="100px" /> : `欢迎回来, ${userInfo.qq}`}
-                            </Text>
+                            {!userInfo ? (
+                                <Skeleton height="20px" width="100px" />
+                            ) : (
+                                <Text fontSize="md" fontWeight="bold">
+                                    {`欢迎回来, ${userInfo.qq}`}
+                                </Text>
+                            )}
                         </Box>
 
                         <HStack gap={2}>
@@ -277,25 +304,23 @@ export function DashBoard() {
                 {' '}
             </Alert>
 
-            {/* Action Toolbar */}
-            <Flex 
-                bg="bg.panel" 
-                p={2} 
-                borderRadius="xl" 
-                shadow="sm" 
-                borderWidth="1px" 
+            <Flex
+                bg="bg.panel"
+                p={2}
+                borderRadius="xl"
+                shadow="sm"
+                borderWidth="1px"
                 borderColor="border.subtle"
                 align="center"
                 wrap="wrap"
                 gap={2}
             >
-                {/* Left Actions: Batch Operations */}
                 <HStack gap={2}>
-                     <Button 
-                        size="sm" 
-                        colorPalette="orange" 
+                     <Button
+                        size="sm"
+                        colorPalette="orange"
                         variant="ghost"
-                        onClick={handleCleanDailyAll} 
+                        onClick={handleCleanDailyAll}
                         loading={count != 0}
                     >
                         <FiTarget /> {isTableView && selectedAccounts.length > 0 ? `清选择(${selectedAccounts.length})` : '清理全部'}
@@ -306,7 +331,7 @@ export function DashBoard() {
                         colorPalette="blue"
                         variant="ghost"
                         // @ts-ignore
-                        to={`${DashBoardRoute.to || ''}BATCH_RUNNER`} 
+                        to={`${DashBoardRoute.to || ''}BATCH_RUNNER`}
                         loading={count != 0}
                     >
                         <FiLayers /> 批量运行
@@ -315,15 +340,13 @@ export function DashBoard() {
 
                 <Spacer />
 
-                {/* Right Actions: View Switch & Account Manage */}
                 <HStack gap={2}>
-                    {/* View Switcher */}
                     <Box bg="bg.subtle" p={1} borderRadius="md" display="flex">
-                        <Tooltip content="表格视图">
-                            <IconButton 
+                        <Tooltip content="表格视图" openDelay={0} closeDelay={0}>
+                            <IconButton
                                 aria-label="List view"
-                                size="xs" 
-                                variant={isTableView ? "solid" : "ghost"} 
+                                size="xs"
+                                variant={isTableView ? "solid" : "ghost"}
                                 colorPalette={isTableView ? "blue" : "gray"}
                                 onClick={() => {
                                     setIsTableView(true);
@@ -333,11 +356,11 @@ export function DashBoard() {
                                 <FiList />
                             </IconButton>
                         </Tooltip>
-                        <Tooltip content="卡片视图">
-                            <IconButton 
+                        <Tooltip content="卡片视图" openDelay={0} closeDelay={0}>
+                            <IconButton
                                 aria-label="Grid view"
-                                size="xs" 
-                                variant={!isTableView ? "solid" : "ghost"} 
+                                size="xs"
+                                variant={!isTableView ? "solid" : "ghost"}
                                 colorPalette={!isTableView ? "blue" : "gray"}
                                 onClick={() => {
                                     setIsTableView(false);
@@ -349,10 +372,9 @@ export function DashBoard() {
                         </Tooltip>
                     </Box>
 
-                    {/* Sync & Default (only for Table && Single Select) */}
                     {isTableView && selectedAccounts.length === 1 && (
                         <HStack gap={1} separator={<Box w="1px" h="15px" bg="border.subtle" />}>
-                             <Tooltip content={`将其他账号配置同步为 ${selectedAccounts[0]} 的配置`}>
+                             <Tooltip content={`将其他账号配置同步为 ${selectedAccounts[0]} 的配置`} openDelay={0} closeDelay={0}>
                                 <IconButton
                                     aria-label="Sync configuration"
                                     size="sm"
@@ -363,7 +385,7 @@ export function DashBoard() {
                                     }}
                                 > <FiCopy /> </IconButton>
                             </Tooltip>
-                            <Tooltip content={`将 ${selectedAccounts[0]} 设为默认账号`}>
+                            <Tooltip content={`将 ${selectedAccounts[0]} 设为默认账号`}  openDelay={0} closeDelay={0}>
                                 <IconButton
                                     aria-label="Set as default"
                                     size="sm"
@@ -374,11 +396,10 @@ export function DashBoard() {
                             </Tooltip>
                         </HStack>
                     )}
-                    
-                    {/* Add / Import / Delete Group */}
+
                      <HStack gap={1}>
                         {userInfo?.clan && (
-                            <Tooltip content="导入账号 (TSV)">
+                            <Tooltip content="导入账号 (TSV)"  openDelay={0} closeDelay={0}>
                                 <IconButton
                                     aria-label="Import accounts"
                                     size="sm"
@@ -395,9 +416,8 @@ export function DashBoard() {
                             onClick={(e) => { (e.target as HTMLInputElement).value = ''; }}
                             display="none"
                         />
-                                
 
-                         <Tooltip content={isTableView && selectedAccounts.length > 0 ? `删除选中(${selectedAccounts.length})` : '删除全部'}>
+                         <Tooltip content={isTableView && selectedAccounts.length > 0 ? `删除选中(${selectedAccounts.length})` : '删除全部'}  openDelay={0} closeDelay={0}>
                             <IconButton
                                 aria-label="Delete selected accounts"
                                 size="sm"
@@ -421,19 +441,19 @@ export function DashBoard() {
                             > <FiUserMinus /> </IconButton>
                         </Tooltip>
                         <Box position="relative">
-                            <Tooltip content={creatAccountSwitch.open ? '取消创建' : '创建新账号'}>
+                            <Tooltip content={creatAccountSwitch.open ? '取消创建' : '创建新账号'}  openDelay={0} closeDelay={0}>
                                 <IconButton
                                     aria-label={creatAccountSwitch.open ? "Confirm creation" : "Create account"}
                                     size="sm"
                                     variant={creatAccountSwitch.open ? "solid" : "solid"}
                                     colorPalette={creatAccountSwitch.open ? "red" : "green"}
                                     onClick={() => {
-                                        if(creatAccountSwitch.open && !alias) creatAccountSwitch.onToggle(); // Close if empty
-                                        else if (creatAccountSwitch.open && alias) handleCreateAccount(); // Submit
-                                        else creatAccountSwitch.onToggle(); // Open
+                                        if(creatAccountSwitch.open && !alias) creatAccountSwitch.onToggle();
+                                        else if (creatAccountSwitch.open && alias) handleCreateAccount();
+                                        else creatAccountSwitch.onToggle();
                                     }}
-                                > 
-                                    {creatAccountSwitch.open ? <FiCheck /> : <FiUserPlus />} 
+                                >
+                                    {creatAccountSwitch.open ? <FiCheck /> : <FiUserPlus />}
                                 </IconButton>
                             </Tooltip>
                         </Box>
@@ -441,16 +461,15 @@ export function DashBoard() {
                 </HStack>
             </Flex>
 
-            {/* Inline Account Creation Input */}
             {creatAccountSwitch.open && (
-                <Flex 
-                    bg="bg.panel" 
-                    p={4} 
-                    borderRadius="xl" 
-                    shadow="sm" 
-                    borderWidth="1px" 
-                    borderColor="green.subtle" 
-                    align="center" 
+                <Flex
+                    bg="bg.panel"
+                    p={4}
+                    borderRadius="xl"
+                    shadow="sm"
+                    borderWidth="1px"
+                    borderColor="green.subtle"
+                    align="center"
                     gap={4}
                     animation="fade-in 0.2s"
                 >
@@ -469,7 +488,7 @@ export function DashBoard() {
             <Alert leastDestructiveRef={cancelRef} isOpen={clearAccountConfirm.open} onClose={clearAccountConfirm.onClose} title="删除所有账号" body={`确定删除所有账号吗？`} onConfirm={handleClearAccounts}>
                 {' '}
             </Alert>
-            
+
             {isTableView ? (
                 <Box flex={1} overflow={'auto'} borderRadius="xl">
                     <Table.Root variant="outline" colorPalette="blue" size="sm" bg="bg.panel" borderRadius="xl" boxShadow="sm" ml="0" mr="auto">
@@ -520,8 +539,9 @@ export function DashBoard() {
                                         isSelected={selectedAccounts.includes(account.name)}
                                         onToggleSelect={() => toggleSelectAccount(account.name)}
                                         defaultAccount={userInfo?.default_account}
-                                        onOpenSyncConfig={(alias) => {
-                                            NiceModal.show(ConfigSyncModal, { sourceAccount: alias });
+                                        getOccupiedNames={occupiedNamesFactory}
+                                        onOpenSyncConfig={(a) => {
+                                            NiceModal.show(ConfigSyncModal, { sourceAccount: a });
                                         }}
                                     />
                                 ))
@@ -554,8 +574,9 @@ export function DashBoard() {
                                             isTableView={isTableView}
                                             isSelected={selectedAccounts.includes(account.name)}
                                             onToggleSelect={() => toggleSelectAccount(account.name)}
-                                            onOpenSyncConfig={(alias) => {
-                                                NiceModal.show(ConfigSyncModal, { sourceAccount: alias });
+                                            getOccupiedNames={occupiedNamesFactory}
+                                            onOpenSyncConfig={(a) => {
+                                                NiceModal.show(ConfigSyncModal, { sourceAccount: a });
                                             }}
                                         />
                                     );
@@ -580,23 +601,76 @@ interface AccountInfoProps {
     onToggleSelect?: () => void;
     defaultAccount?: string;
     onOpenSyncConfig?: (alias: string) => void;
+    getOccupiedNames: (selfAlias: string) => Set<string>;
 }
 
-function AccountInfo({ account, onToggle, increaseCount, decreaseCount, updateAccountInfo, isTableView = false, isSelected = false, onToggleSelect, defaultAccount, onOpenSyncConfig }: AccountInfoProps) {
+function AccountInfo({
+    account,
+    onToggle,
+    increaseCount,
+    decreaseCount,
+    updateAccountInfo,
+    isTableView = false,
+    isSelected = false,
+    onToggleSelect,
+    defaultAccount,
+    onOpenSyncConfig,
+    getOccupiedNames,
+}: AccountInfoProps) {
     const buttomLoading = useDisclosure();
     const alias = account.name;
     const deleteConfirm = useDisclosure();
-    
+    const navigate = useNavigate();
+    const importFileRef = useRef<HTMLInputElement>(null);
+    const cancelRef = React.useRef<HTMLButtonElement>(null);
+
+    const [isEditingName, setIsEditingName] = useState(false);
+    const [displayName, setDisplayName] = useState(() => getDisplayName(alias));
+    const [nameDraft, setNameDraft] = useState(displayName);
+
+    const clean = account.daily_clean_time;
+    const cleanStatus = clean?.status || '未知';
+    const cleanTime = clean?.time || '';
+
+    const statusMeta =
+        cleanStatus === '成功' || cleanStatus === '跳过'
+            ? { color: 'green' as const, icon: <FiCheck />, label: cleanStatus === '跳过' ? '跳过' : '完成' }
+            : cleanStatus === '警告' || cleanStatus === '中止'
+              ? { color: 'orange' as const, icon: <FiActivity />, label: cleanStatus }
+              : cleanStatus === '错误'
+                ? { color: 'red' as const, icon: <FiUserX />, label: '错误' }
+                : { color: 'gray' as const, icon: <FiActivity />, label: cleanStatus };
+
+    useEffect(() => {
+        const latest = getDisplayName(alias);
+        setDisplayName(latest);
+        if (!isEditingName) setNameDraft(latest);
+    }, [alias, isEditingName]);
+
     const handleCleanDaily = async () => {
         buttomLoading.onOpen();
         increaseCount();
-        toaster.create({ type: 'info', title: `开始为${alias}清理日常...` });
+        toaster.create({ type: 'info', title: `开始为${displayName || alias}清理日常...` });
         try {
             const res = await postAccountAreaDaily(alias);
-            toaster.create({ type: 'success', title: `${alias}清日常成功` });
             updateAccountInfo(res);
-        } catch(err: any) {
-             toaster.create({ type: 'error', title: `${alias}清日常失败`, description: (err?.response?.data as string) || '网络错误' });
+
+            const st = res?.daily_clean_time?.status || '';
+            if (st === '错误') {
+                toaster.create({ type: 'error', title: `${displayName || alias}清日常结束`, description: st });
+            } else if (st === '警告' || st === '中止') {
+                toaster.create({ type: 'warning', title: `${displayName || alias}清日常完成(${st})`, description: st });
+            } else if (st === '成功' || st === '跳过') {
+                toaster.create({ type: 'success', title: `${displayName || alias}清日常成功` });
+            } else {
+                toaster.create({ type: 'success', title: `${displayName || alias}清日常完成`, description: st || undefined });
+            }
+        } catch (err: any) {
+            toaster.create({
+                type: 'error',
+                title: `${displayName || alias}清日常失败`,
+                description: (err?.response?.data as string) || err?.message || '网络错误',
+            });
         } finally {
             buttomLoading.onClose();
             decreaseCount();
@@ -612,7 +686,11 @@ function AccountInfo({ account, onToggle, increaseCount, decreaseCount, updateAc
                 onToggle();
             })
             .catch((err: AxiosError) => {
-                toaster.create({ type: 'error', title: '删除账号失败', description: (err?.response?.data as string) || '网络错误' });
+                toaster.create({
+                    type: 'error',
+                    title: '删除账号失败',
+                    description: (err?.response?.data as string) || '网络错误',
+                });
             });
     };
 
@@ -624,170 +702,545 @@ function AccountInfo({ account, onToggle, increaseCount, decreaseCount, updateAc
                 await NiceModal.show(ResultInfoModal, { alias: alias, title: '日常', resultInfo: res });
             })
             .catch(async (err: AxiosError) => {
-                toaster.create({ type: 'error', title: '获取日常结果失败', description: (await (err?.response?.data as Blob).text()) || '网络错误' });
+                toaster.create({
+                    type: 'error',
+                    title: '获取日常结果失败',
+                    description: (await (err?.response?.data as Blob).text()) || '网络错误',
+                });
             });
     };
 
-    const cancelRef = React.useRef<HTMLButtonElement>(null);
+    const goDetail = () => {
+        void navigate({ to: `${DashBoardRoute.to || ''}${alias}` as any });
+    };
 
-    // Status Badge Helper
-    const StatusBadge = () => {
-        let color = "red";
-        let icon = <FiUserX />;
-        let text = "未知";
-        
-        if (account.daily_clean_time.status === '成功') {
-            color = "green";
-            icon = <FiCheck />;
-            text = "完成";
-        } else if (account.daily_clean_time.status === '警告') {
-            color = "orange";
-            icon = <FiActivity />;
-            text = "警告";
+    const startEditName = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        setNameDraft(displayName);
+        setIsEditingName(true);
+    };
+
+    const commitDisplayName = () => {
+        const next = nameDraft.trim();
+        if (!next) {
+            localStorage.removeItem(DISPLAY_NAME_KEY(alias));
+            setDisplayName(alias);
+            setNameDraft(alias);
+            setIsEditingName(false);
+            return;
         }
+        const occupied = getOccupiedNames(alias);
+        if (occupied.has(next) && next !== displayName) {
+            toaster.create({
+                type: 'error',
+                title: '显示名冲突',
+                description: `「${next}」已被其他账号使用`,
+            });
+            setNameDraft(displayName);
+            setIsEditingName(false);
+            return;
+        }
+        if (next === alias) {
+            localStorage.removeItem(DISPLAY_NAME_KEY(alias));
+        } else {
+            localStorage.setItem(DISPLAY_NAME_KEY(alias), next);
+        }
+        setDisplayName(next);
+        setIsEditingName(false);
+    };
 
-        return (
-             <Tag.Root colorPalette={color} variant="subtle">
-                <Tag.StartElement>{icon}</Tag.StartElement>
-                <Tag.Label>{text} {account.daily_clean_time.time}</Tag.Label>
-            </Tag.Root>
-        )
-    }
+    const toCheckedConfigItem = (
+        type: ConfigType,
+        candidates: Candidate[],
+        value: unknown,
+    ): ConfigValue | undefined => {
+        switch (type) {
+            case 'bool':
+            case 'single':
+                if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+                    return value as ConfigValue;
+                }
+                break;
+            case 'int':
+                if (typeof value === 'number') return value;
+                break;
+            case 'text':
+                if (typeof value === 'string') return value;
+                break;
+            case 'time':
+                if (typeof value === 'string' && value.match(/^\d{2}:\d{2}$/) !== null) return value;
+                break;
+            case 'multi':
+            case 'multi_search': {
+                if (!Array.isArray(value)) break;
+                const checkedArray: (string | number)[] = [];
+                for (const item of value) {
+                    if (typeof item !== 'number' && typeof item !== 'string') continue;
+                    if (candidates.find((v) => item === v.value)) checkedArray.push(item);
+                }
+                return checkedArray;
+            }
+        }
+        return undefined;
+    };
 
+    const realImportByModule = (
+        module: ModuleResponse,
+        configs: Record<string, ConfigValue>,
+    ): Record<string, ConfigValue> => {
+        const uploadConfig: Record<string, ConfigValue> = {};
+        for (const moduleKey in module.info) {
+            if (configs[moduleKey] !== undefined && typeof configs[moduleKey] === 'boolean') {
+                uploadConfig[moduleKey] = configs[moduleKey];
+            }
+            const moduleConf = module.info[moduleKey].config;
+            for (const moduleConfKey in moduleConf) {
+                const moduleItem = moduleConf[moduleConfKey];
+                const confItem = toCheckedConfigItem(
+                    moduleItem.config_type,
+                    moduleItem.candidates,
+                    configs[moduleConfKey],
+                );
+                if (confItem !== undefined) {
+                    uploadConfig[moduleConfKey] = confItem;
+                }
+            }
+        }
+        return uploadConfig;
+    };
 
-    // 表格视图渲染
+    const handleImportConfigFile = async (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        event.target.value = '';
+        if (!file) return;
+
+        buttomLoading.onOpen();
+        try {
+            const rawCfg = await file.text();
+            let configs: Record<string, Record<string, ConfigValue>>;
+            try {
+                configs = JSON.parse(decodeURIComponent(atob(rawCfg.trim()))) as Record<
+                    string,
+                    Record<string, ConfigValue>
+                >;
+            } catch {
+                throw new Error('配置文件格式无效，请检查选取的配置文件。');
+            }
+
+            const accountDetail = await getAccount(alias);
+            const areas = accountDetail?.area || [];
+            if (!areas.length) {
+                throw new Error('该账号暂无可用区服，无法导入配置');
+            }
+
+            const configItems = await Promise.all(
+                areas.map((area: { key: string }) => getAccountConfig(alias, area.key)),
+            );
+            const uploadConfig: Record<string, ConfigValue> = {};
+            const importedFav: Record<string, string[]> = {};
+
+            configItems.forEach((value, index) => {
+                const areaKey = areas[index].key;
+                const areaConfig = configs[areaKey];
+                if (!areaConfig) return;
+
+                Object.assign(uploadConfig, realImportByModule(value, areaConfig));
+
+                for (const key in areaConfig) {
+                    if (key.startsWith('_fav_')) {
+                        importedFav[areaKey] = importedFav[areaKey] || [];
+                        if (areaConfig[key] === true) {
+                            importedFav[areaKey].push(key.slice(5));
+                        }
+                    } else if (uploadConfig[key] === undefined && areaConfig[key] !== undefined) {
+                        uploadConfig[key] = areaConfig[key];
+                    }
+                }
+            });
+
+            localStorage.setItem(`autopcr_fav_${alias}`, JSON.stringify(importedFav));
+            await putAccountConfigs(alias, uploadConfig);
+            toaster.create({ type: 'success', title: '配置导入成功' });
+            onToggle();
+        } catch (err) {
+            if (err instanceof AxiosError) {
+                toaster.create({
+                    type: 'error',
+                    title: '配置导入失败',
+                    description: (err.response?.data as string) || '网络错误',
+                });
+            } else {
+                toaster.create({
+                    type: 'error',
+                    title: '配置导入失败',
+                    description: (err as Error).message,
+                });
+            }
+        } finally {
+            buttomLoading.onClose();
+        }
+    };
+
+    const ActionButtons = ({
+        size = 'xs' as const,
+        flexMode = false,
+    }: {
+        size?: 'xs' | 'sm' | 'md';
+        flexMode?: boolean;
+    }) => (
+        <HStack
+            gap={flexMode ? 0 : 1}
+            w={flexMode ? 'full' : undefined}
+            justify={flexMode ? 'space-between' : undefined}
+            align="center"
+            onClick={(e) => e.stopPropagation()}
+        >
+            <input
+                ref={importFileRef}
+                type="file"
+                accept=".autopcrcfg"
+                style={{ display: 'none' }}
+                onChange={handleImportConfigFile}
+            />
+
+            <Tooltip content="立刻清理"  openDelay={0} closeDelay={0}>
+                <IconButton
+                    aria-label="Clean Daily"
+                    size={size}
+                    flex={flexMode ? '1' : undefined}
+                    variant="ghost"
+                    colorPalette="orange"
+                    onClick={handleCleanDaily}
+                    loading={buttomLoading.open}
+                >
+                    <FiTarget />
+                </IconButton>
+            </Tooltip>
+
+            <Tooltip content="导入配置" openDelay={0} closeDelay={0}>
+                <IconButton
+                    aria-label="Import Config"
+                    size={size}
+                    flex={flexMode ? '1' : undefined}
+                    variant="ghost"
+                    colorPalette="blue"
+                    onClick={() => importFileRef.current?.click()}
+                    loading={buttomLoading.open}
+                >
+                    <FiUpload />
+                </IconButton>
+            </Tooltip>
+
+            <Tooltip content="同步配置" openDelay={0} closeDelay={0}>
+                <IconButton
+                    aria-label="Sync Config"
+                    size={size}
+                    flex={flexMode ? '1' : undefined}
+                    variant="ghost"
+                    colorPalette="teal"
+                    onClick={() => onOpenSyncConfig && onOpenSyncConfig(alias)}
+                    loading={buttomLoading.open}
+                >
+                    <FiCopy />
+                </IconButton>
+            </Tooltip>
+
+            <Tooltip content="运行结果" openDelay={0} closeDelay={0}>
+                <IconButton
+                    aria-label="View Results"
+                    size={size}
+                    flex={flexMode ? '1' : undefined}
+                    variant="ghost"
+                    colorPalette="green"
+                    onClick={handleDailyResult}
+                    loading={buttomLoading.open}
+                >
+                    <FiActivity />
+                </IconButton>
+            </Tooltip>
+        </HStack>
+    );
+
+    const NameEditor = ({ fontSize = 'sm' }: { fontSize?: string }) =>
+        isEditingName ? (
+            <Input
+                size="sm"
+                value={nameDraft}
+                autoFocus
+                onClick={(e) => e.stopPropagation()}
+                onChange={(e) => setNameDraft(e.target.value)}
+                onBlur={commitDisplayName}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+                    if (e.key === 'Escape') {
+                        setNameDraft(displayName);
+                        setIsEditingName(false);
+                    }
+                }}
+                fontWeight="bold"
+                fontSize={fontSize}
+                maxW="12em"
+                lineHeight="1"
+            />
+        ) : (
+            <Text
+                as="span"
+                fontWeight="bold"
+                fontSize={fontSize}
+                lineHeight="1"
+                cursor="text"
+                title="点击修改显示名称"
+                onClick={startEditName}
+                _hover={{ color: 'blue.fg' }}
+                whiteSpace="nowrap"
+            >
+                {displayName}
+            </Text>
+        );
+
     if (isTableView) {
         return (
-            <Table.Row
-                key={alias}
-                bg="bg.panel"
-                _hover={{
-                    bg: "bg.muted",
-                    transition: 'background-color 0.2s',
-                }}
-            >
-                <Table.Cell px={3} py={3} width="50px">
-                    <Checkbox checked={isSelected} onCheckedChange={onToggleSelect} colorPalette="blue" />
+            <Table.Row key={alias} bg="bg.panel" _hover={{ bg: 'bg.muted' }}>
+                <Table.Cell px={3} py={3} width="50px" onClick={(e) => e.stopPropagation()}>
+                    <Flex align="center" minH="2.5em">
+                        <Checkbox
+                            checked={isSelected}
+                            onCheckedChange={onToggleSelect}
+                            colorPalette="blue"
+                        />
+                    </Flex>
                 </Table.Cell>
-                <Table.Cell px={0} py={3}>
-                     <HStack gap={2}>
-                        <Box w="32px" h="32px" bg="blue.subtle" color="blue.fg" borderRadius="full" display="flex" alignItems="center" justifyContent="center" fontSize="sm">
-                            {alias.charAt(0).toUpperCase()}
+
+                <Table.Cell px={2} py={3}>
+                    <Flex
+                        align="center"
+                        gap={2}
+                        minW={0}
+                        w="full"
+                        cursor="pointer"
+                        onClick={goDetail}
+                        title="进入详细设置"
+                    >
+                        <Flex
+                            boxSize="2em"
+                            flexShrink={0}
+                            bg="blue.subtle"
+                            color="blue.fg"
+                            borderRadius="full"
+                            align="center"
+                            justify="center"
+                            fontSize="sm"
+                            lineHeight="1"
+                        >
+                            {displayName.charAt(0).toUpperCase()}
+                        </Flex>
+
+                        <Flex align="center" gap={1} minW={0} flex="1" lineHeight="1">
+                            <Box
+                                onClick={(e) => e.stopPropagation()}
+                                display="flex"
+                                alignItems="center"
+                                lineHeight="1"
+                            >
+                                <NameEditor fontSize="sm" />
+                            </Box>
+                            {displayName !== alias && (
+                                <Text
+                                    as="span"
+                                    fontSize="xs"
+                                    color="fg.muted"
+                                    whiteSpace="nowrap"
+                                    lineHeight="1"
+                                >
+                                    {alias}
+                                </Text>
+                            )}
+                            {defaultAccount === account.name && (
+                                <Tag.Root size="sm" colorPalette="purple" variant="solid" flexShrink={0}>
+                                    <Tag.Label>默认</Tag.Label>
+                                </Tag.Root>
+                            )}
+                            {account.clan_forbid && (
+                                <Tag.Root size="sm" colorPalette="red" variant="solid" flexShrink={0}>
+                                    <Tag.Label>公会战禁用</Tag.Label>
+                                </Tag.Root>
+                            )}
+                        </Flex>
+
+                        <Box flexShrink={0} onClick={(e) => e.stopPropagation()}>
+                            <Alert
+                                leastDestructiveRef={cancelRef}
+                                isOpen={deleteConfirm.open}
+                                onClose={deleteConfirm.onClose}
+                                title="删除账号"
+                                body={`确定删除账号${alias}吗？`}
+                                onConfirm={handleDeleteAccount}
+                            >
+                                {' '}
+                            </Alert>
+                            <IconButton
+                                aria-label="Delete"
+                                size="xs"
+                                variant="ghost"
+                                colorPalette="gray"
+                                title="删除账号"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    deleteConfirm.onOpen();
+                                }}
+                                _hover={{ bg: 'red.subtle', color: 'red.fg' }}
+                            >
+                                <FiX />
+                            </IconButton>
                         </Box>
-                        <Stack gap={0}>
-                            <Text fontWeight="bold" fontSize="sm">{alias}</Text>
-                            <HStack gap={1}>
-                                {defaultAccount === account.name && <Tag.Root size="sm" colorPalette="purple" variant="solid"><Tag.Label>默认</Tag.Label></Tag.Root>}
-                                {account.clan_forbid && <Tag.Root size="sm" colorPalette="red" variant="solid"><Tag.Label>公会战禁用</Tag.Label></Tag.Root>}
-                            </HStack>
-                        </Stack>
-                    </HStack>
+                    </Flex>
                 </Table.Cell>
-                <Table.Cell px={3} py={3}>
-                    <StatusBadge />
+
+                <Table.Cell
+                    px={3}
+                    py={3}
+                    cursor="pointer"
+                    onClick={goDetail}
+                    title="进入详细设置"
+                >
+                    <Flex align="center" gap={2} minW={0}>
+                        <Tag.Root colorPalette={statusMeta.color} variant="subtle" flexShrink={0}>
+                            <Tag.StartElement>{statusMeta.icon}</Tag.StartElement>
+                            <Tag.Label>
+                                {statusMeta.label}
+                                {cleanTime ? ` ${cleanTime}` : ''}
+                            </Tag.Label>
+                        </Tag.Root>
+                    </Flex>
                 </Table.Cell>
-                <Table.Cell px={3} py={3}>
-                    <HStack gap={1}>
-                        <Tooltip content="配置">
-                            <IconButton aria-label="Settings" as={Link} // @ts-ignore
-                            to={`${DashBoardRoute.to || ''}${account.name}`} size="xs" variant="ghost" colorPalette="blue"> <FiSettings /> </IconButton>
-                        </Tooltip>
 
-                        <Tooltip content="清理日常">
-                            <IconButton aria-label="Clean Daily" size="xs" variant="ghost" colorPalette="orange" onClick={handleCleanDaily} loading={buttomLoading.open}> <FiTarget /> </IconButton>
-                        </Tooltip>
-
-                        <Tooltip content="同步配置">
-                             <IconButton aria-label="Sync Config" size="xs" variant="ghost" colorPalette="teal" onClick={() => onOpenSyncConfig && onOpenSyncConfig(alias)} loading={buttomLoading.open}> <FiCopy /> </IconButton>
-                        </Tooltip>
-
-                        <Tooltip content="结果">
-                             <IconButton aria-label="View Results" size="xs" variant="ghost" colorPalette="green" onClick={handleDailyResult} loading={buttomLoading.open}> <FiActivity /> </IconButton>
-                        </Tooltip>
-                    </HStack>
+                <Table.Cell
+                    px={3}
+                    py={3}
+                    cursor="pointer"
+                    onClick={goDetail}
+                    title="进入详细设置"
+                >
+                    <ActionButtons size="xs" />
                 </Table.Cell>
             </Table.Row>
         );
     }
 
-    // 卡片视图渲染
     return (
-        <Card.Root 
-            key={alias} 
-            bg="bg.panel" 
-            shadow="sm" 
+        <Card.Root
+            key={alias}
+            bg="bg.panel"
+            shadow="sm"
             borderRadius="2xl"
             borderWidth="1px"
             borderColor="border.subtle"
             transition="all 0.2s"
-            _hover={{ shadow: 'lg', transform: 'translateY(-2px)', borderColor: "blue.focusRing" }}
+            _hover={{ shadow: 'lg', transform: 'translateY(-2px)', borderColor: 'blue.focusRing' }}
         >
-            <Card.Header pb={2}>
-                <Flex justify="space-between" align="start">
-                    <Stack gap={1}>
-                        <HStack>
-                             <Radio value={alias} colorPalette="purple" />
-                             <Text fontWeight="bold" fontSize="lg" lineHeight="1.2">{alias}</Text>
-                             {account.clan_forbid && <Tag.Root size="sm" colorPalette="red" variant="subtle"><Tag.Label>禁用</Tag.Label></Tag.Root>}
-                        </HStack>
-                    </Stack>
-                    
-                     <Alert leastDestructiveRef={cancelRef} isOpen={deleteConfirm.open} onClose={deleteConfirm.onClose} title="删除账号" body={`确定删除账号${alias}吗？`} onConfirm={handleDeleteAccount}>
-                        {' '}
-                    </Alert>
-
-                     <IconButton 
-                        size="xs" 
-                        variant="ghost" 
-                        colorPalette="gray" 
-                        aria-label="Delete" 
-                        onClick={deleteConfirm.onOpen}
-                        _hover={{ bg: "red.subtle", color: "red.fg" }}
-                    >
-                        <CloseButton />
-                    </IconButton>
-                </Flex>
-            </Card.Header>
-
-            <Card.Body py={2}>
-                <Stack gap={3} mt={2}>
-                    <Box bg="bg.subtle" p={2} borderRadius="lg">
-                         <Flex justify="space-between" align="center" mb={1}>
-                            <Text fontSize="xs" color="fg.muted">上次运行</Text>
-                            <Text fontSize="xs" fontWeight="bold">{account.daily_clean_time.time}</Text>
-                        </Flex>
-                        <Flex justify="space-between" align="center">
-                            <Text fontSize="xs" color="fg.muted">状态</Text>
-                             <Tag.Root 
-                                size="sm" 
-                                colorPalette={account.daily_clean_time.status === '成功' ? "green" : account.daily_clean_time.status === '警告' ? "orange" : "red"} 
+            <Box
+                cursor="pointer"
+                onClick={goDetail}
+                title="进入详细设置"
+            >
+                <Card.Header pb={2}>
+                    <Flex justify="space-between" align="start" gap={2}>
+                        <Flex align="center" gap={2} minW={0} flex="1" pt={0.5}>
+                            <Box
+                                onClick={(e) => e.stopPropagation()}
+                                flexShrink={0}
+                                display="flex"
+                                alignItems="center"
+                                lineHeight="1"
                             >
-                                <Tag.Label>{account.daily_clean_time.status}</Tag.Label>
+                                <Radio value={alias} colorPalette="purple" />
+                            </Box>
+                            <Box
+                                maxW="55%"
+                                minW={0}
+                                onClick={(e) => e.stopPropagation()}
+                                display="flex"
+                                alignItems="center"
+                                lineHeight="1"
+                            >
+                                <NameEditor fontSize="lg" />
+                            </Box>
+                            {displayName !== alias && (
+                                <Text
+                                    as="span"
+                                    fontSize="xs"
+                                    color="fg.muted"
+                                    whiteSpace="nowrap"
+                                    overflow="hidden"
+                                    textOverflow="ellipsis"
+                                    maxW="30%"
+                                    lineHeight="1"
+                                    title={alias}
+                                >
+                                    {alias}
+                                </Text>
+                            )}
+                            {account.clan_forbid && (
+                                <Tag.Root size="sm" colorPalette="red" variant="subtle" flexShrink={0}>
+                                    <Tag.Label>禁用</Tag.Label>
+                                </Tag.Root>
+                            )}
+                        </Flex>
+
+                        <Box onClick={(e) => e.stopPropagation()} flexShrink={0}>
+                            <Alert
+                                leastDestructiveRef={cancelRef}
+                                isOpen={deleteConfirm.open}
+                                onClose={deleteConfirm.onClose}
+                                title="删除账号"
+                                body={`确定删除账号${alias}吗？`}
+                                onConfirm={handleDeleteAccount}
+                            >
+                                {' '}
+                            </Alert>
+                            <IconButton
+                                size="xs"
+                                variant="ghost"
+                                colorPalette="gray"
+                                aria-label="Delete"
+                                title="删除账号"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    deleteConfirm.onOpen();
+                                }}
+                                _hover={{ bg: 'red.subtle', color: 'red.fg' }}
+                            >
+                                <FiX />
+                            </IconButton>
+                        </Box>
+                    </Flex>
+                </Card.Header>
+
+                <Card.Body py={2}>
+                    <Box bg="bg.subtle" p={2} borderRadius="lg">
+                        <Flex justify="space-between" align="center" mb={1} gap={2}>
+                            <Text fontSize="xs" color="fg.muted">
+                                上次运行
+                            </Text>
+                            <Text fontSize="xs" fontWeight="bold">
+                                {cleanTime || '—'}
+                            </Text>
+                        </Flex>
+                        <Flex justify="space-between" align="center" gap={2}>
+                            <Text fontSize="xs" color="fg.muted" flexShrink={0}>
+                                状态
+                            </Text>
+                            <Tag.Root size="sm" colorPalette={statusMeta.color} flexShrink={0}>
+                                <Tag.StartElement>{statusMeta.icon}</Tag.StartElement>
+                                <Tag.Label>{cleanStatus}</Tag.Label>
                             </Tag.Root>
                         </Flex>
                     </Box>
-                </Stack>
-            </Card.Body>
+                </Card.Body>
+            </Box>
 
             <Card.Footer pt={2}>
-                 <HStack gap={0} w="full" justify="space-between">
-                     <Tooltip content="详细配置">
-                        <IconButton aria-label="Settings" flex="1" variant="ghost" colorPalette="blue" as={Link} // @ts-ignore
-                            to={DashBoardRoute.to + alias}> <FiSettings /> </IconButton>
-                    </Tooltip>
-                    
-                     <Tooltip content="立即清理">
-                         <IconButton aria-label="Clean Daily" flex="1" variant="ghost" colorPalette="orange" onClick={handleCleanDaily} loading={buttomLoading.open}> <FiTarget /> </IconButton>
-                    </Tooltip>
-
-                    <Tooltip content="同步配置">
-                         <IconButton aria-label="Sync Config" flex="1" variant="ghost" colorPalette="teal" onClick={() => onOpenSyncConfig && onOpenSyncConfig(alias)} loading={buttomLoading.open}> <FiCopy /> </IconButton>
-                    </Tooltip>
-                    
-                    <Tooltip content="运行结果">
-                         <IconButton aria-label="View Result" flex="1" variant="ghost" colorPalette="green" onClick={handleDailyResult} loading={buttomLoading.open}> <FiActivity /> </IconButton>
-                    </Tooltip>
-                </HStack>
+                <ActionButtons size="md" flexMode />
             </Card.Footer>
         </Card.Root>
     );

--- a/src/components/Account/DashBoard.tsx
+++ b/src/components/Account/DashBoard.tsx
@@ -627,6 +627,7 @@ function AccountInfo({
     const [isEditingName, setIsEditingName] = useState(false);
     const [displayName, setDisplayName] = useState(() => getDisplayName(alias));
     const [nameDraft, setNameDraft] = useState(displayName);
+    const composingRef = useRef(false);
 
     const clean = account.daily_clean_time;
     const cleanStatus = clean?.status || '未知';
@@ -695,7 +696,7 @@ function AccountInfo({
     };
 
     const handleDailyResult = () => {
-        toaster.create({ type: 'info', title: `正在获取${alias}的日常结果...` });
+        toaster.create({ type: 'info', title: `正在获取${displayName || alias}的日常结果...` });
         getAccountDailyResultList(alias)
             .then(async (res) => {
                 toaster.create({ type: 'success', title: '获取日常结果成功' });
@@ -714,23 +715,41 @@ function AccountInfo({
         void navigate({ to: `${DashBoardRoute.to || ''}${alias}` as any });
     };
 
+    const nameInputRef = useRef<HTMLInputElement>(null);
+
     const startEditName = (e: React.MouseEvent) => {
         e.stopPropagation();
         setNameDraft(displayName);
         setIsEditingName(true);
     };
 
+    useEffect(() => {
+        if (!isEditingName) return;
+        const el = nameInputRef.current;
+        if (!el) return;
+        el.focus();
+        // 光标放到末尾，避免整段被选中
+        const len = el.value.length;
+        el.setSelectionRange(len, len);
+    }, [isEditingName]);
+
     const commitDisplayName = () => {
         const next = nameDraft.trim();
-        if (!next) {
+        // 空或改回原始 alias → 清除自定义显示名
+        if (!next || next === alias) {
             localStorage.removeItem(DISPLAY_NAME_KEY(alias));
             setDisplayName(alias);
             setNameDraft(alias);
             setIsEditingName(false);
             return;
         }
+        // 没改
+        if (next === displayName) {
+            setIsEditingName(false);
+            return;
+        }
         const occupied = getOccupiedNames(alias);
-        if (occupied.has(next) && next !== displayName) {
+        if (occupied.has(next)) {
             toaster.create({
                 type: 'error',
                 title: '显示名冲突',
@@ -740,14 +759,83 @@ function AccountInfo({
             setIsEditingName(false);
             return;
         }
-        if (next === alias) {
-            localStorage.removeItem(DISPLAY_NAME_KEY(alias));
-        } else {
-            localStorage.setItem(DISPLAY_NAME_KEY(alias), next);
-        }
+        localStorage.setItem(DISPLAY_NAME_KEY(alias), next);
         setDisplayName(next);
         setIsEditingName(false);
     };
+
+    // 始终同一 Input：展示/编辑同一位置，避免 Text→Input 错位
+    const nameInput = (
+        <Input
+            ref={nameInputRef}
+            size="sm"
+            value={isEditingName ? nameDraft : displayName}
+            readOnly={!isEditingName}
+            title={isEditingName ? undefined : '点击修改显示名称'}
+            onClick={(e) => {
+                e.stopPropagation();
+                if (!isEditingName) startEditName(e);
+            }}
+            onChange={(e) => {
+                if (!isEditingName) return;
+                setNameDraft(e.target.value);
+            }}
+            onCompositionStart={() => {
+                composingRef.current = true;
+            }}
+            onCompositionEnd={(e) => {
+                composingRef.current = false;
+                setNameDraft((e.target as HTMLInputElement).value);
+            }}
+            onBlur={() => {
+                if (!isEditingName) return;
+                if (composingRef.current) return;
+                commitDisplayName();
+            }}
+            onKeyDown={(e) => {
+                if (!isEditingName) return;
+                if (composingRef.current) return;
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    (e.target as HTMLInputElement).blur();
+                }
+                if (e.key === 'Escape') {
+                    e.preventDefault();
+                    setNameDraft(displayName);
+                    setIsEditingName(false);
+                }
+            }}
+            fontWeight="bold"
+            fontSize="inherit"
+            lineHeight="1.25"
+            h="2rem"
+            minH="2rem"
+            minW="4.5em"
+            w="auto"
+            maxW="14em"
+            px={2}
+            py={0}
+            borderRadius="md"
+            borderWidth="1px"
+            borderColor={isEditingName ? 'blue.focusRing' : 'transparent'}
+            bg={isEditingName ? 'bg.panel' : 'transparent'}
+            boxShadow="none"
+            cursor={isEditingName ? 'text' : 'text'}
+            _hover={
+                isEditingName
+                    ? undefined
+                    : { bg: 'bg.subtle', borderColor: 'border.subtle' }
+            }
+            _focusVisible={{
+                borderColor: 'blue.focusRing',
+                boxShadow: 'none',
+            }}
+            css={{
+                // 取消部分浏览器只读态发灰
+                '&:read-only': { opacity: 1, cursor: 'text' },
+            }}
+        />
+    );
 
     const toCheckedConfigItem = (
         type: ConfigType,
@@ -881,13 +969,7 @@ function AccountInfo({
         }
     };
 
-    const ActionButtons = ({
-        size = 'xs' as const,
-        flexMode = false,
-    }: {
-        size?: 'xs' | 'sm' | 'md';
-        flexMode?: boolean;
-    }) => (
+    const renderActionButtons = (size: 'xs' | 'sm' | 'md' = 'xs', flexMode = false) => (
         <HStack
             gap={flexMode ? 0 : 1}
             w={flexMode ? 'full' : undefined}
@@ -903,7 +985,7 @@ function AccountInfo({
                 onChange={handleImportConfigFile}
             />
 
-            <Tooltip content="立刻清理"  openDelay={0} closeDelay={0}>
+            <Tooltip content="立刻清理" openDelay={0} closeDelay={0}>
                 <IconButton
                     aria-label="Clean Daily"
                     size={size}
@@ -961,42 +1043,6 @@ function AccountInfo({
         </HStack>
     );
 
-    const NameEditor = ({ fontSize = 'sm' }: { fontSize?: string }) =>
-        isEditingName ? (
-            <Input
-                size="sm"
-                value={nameDraft}
-                autoFocus
-                onClick={(e) => e.stopPropagation()}
-                onChange={(e) => setNameDraft(e.target.value)}
-                onBlur={commitDisplayName}
-                onKeyDown={(e) => {
-                    if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
-                    if (e.key === 'Escape') {
-                        setNameDraft(displayName);
-                        setIsEditingName(false);
-                    }
-                }}
-                fontWeight="bold"
-                fontSize={fontSize}
-                maxW="12em"
-                lineHeight="1"
-            />
-        ) : (
-            <Text
-                as="span"
-                fontWeight="bold"
-                fontSize={fontSize}
-                lineHeight="1"
-                cursor="text"
-                title="点击修改显示名称"
-                onClick={startEditName}
-                _hover={{ color: 'blue.fg' }}
-                whiteSpace="nowrap"
-            >
-                {displayName}
-            </Text>
-        );
 
     if (isTableView) {
         return (
@@ -1021,36 +1067,41 @@ function AccountInfo({
                         onClick={goDetail}
                         title="进入详细设置"
                     >
-                        <Flex
-                            boxSize="2em"
-                            flexShrink={0}
-                            bg="blue.subtle"
-                            color="blue.fg"
-                            borderRadius="full"
-                            align="center"
-                            justify="center"
-                            fontSize="sm"
-                            lineHeight="1"
-                        >
-                            {displayName.charAt(0).toUpperCase()}
-                        </Flex>
-
+                        {/* ✅ 补回内层 Flex 容器 */}
                         <Flex align="center" gap={1} minW={0} flex="1" lineHeight="1">
+                            <Flex
+                                boxSize="2em"
+                                flexShrink={0}
+                                bg="blue.subtle"
+                                color="blue.fg"
+                                borderRadius="full"
+                                align="center"
+                                justify="center"
+                                fontSize="sm"
+                                lineHeight="1"
+                            >
+                                {displayName.charAt(0).toUpperCase()}
+                            </Flex>
+
                             <Box
                                 onClick={(e) => e.stopPropagation()}
                                 display="flex"
                                 alignItems="center"
-                                lineHeight="1"
+                                h="2rem"
+                                fontSize="sm"
+                                flex="0 1 auto"
+                                minW={0}
                             >
-                                <NameEditor fontSize="sm" />
+                                {nameInput}
                             </Box>
+
                             {displayName !== alias && (
                                 <Text
                                     as="span"
                                     fontSize="xs"
                                     color="fg.muted"
-                                    whiteSpace="nowrap"
-                                    lineHeight="1"
+                                                    whiteSpace="nowrap"
+                    lineHeight="1"
                                 >
                                     {alias}
                                 </Text>
@@ -1121,7 +1172,7 @@ function AccountInfo({
                     onClick={goDetail}
                     title="进入详细设置"
                 >
-                    <ActionButtons size="xs" />
+                    {renderActionButtons('xs')}
                 </Table.Cell>
             </Table.Row>
         );
@@ -1145,7 +1196,7 @@ function AccountInfo({
             >
                 <Card.Header pb={2}>
                     <Flex justify="space-between" align="start" gap={2}>
-                        <Flex align="center" gap={2} minW={0} flex="1" pt={0.5}>
+                        <Flex align="center" gap={0} minW={0} flex="1" pt={0}>
                             <Box
                                 onClick={(e) => e.stopPropagation()}
                                 flexShrink={0}
@@ -1156,14 +1207,16 @@ function AccountInfo({
                                 <Radio value={alias} colorPalette="purple" />
                             </Box>
                             <Box
-                                maxW="55%"
+                                maxW="70%"
                                 minW={0}
                                 onClick={(e) => e.stopPropagation()}
                                 display="flex"
                                 alignItems="center"
-                                lineHeight="1"
+                                h="2rem"
+                                fontSize="lg"
+                                flex="0 1 auto"
                             >
-                                <NameEditor fontSize="lg" />
+                                {nameInput}
                             </Box>
                             {displayName !== alias && (
                                 <Text
@@ -1240,7 +1293,7 @@ function AccountInfo({
             </Box>
 
             <Card.Footer pt={2}>
-                <ActionButtons size="md" flexMode />
+                {renderActionButtons('md', true)}
             </Card.Footer>
         </Card.Root>
     );

--- a/src/components/Account/Info.tsx
+++ b/src/components/Account/Info.tsx
@@ -32,6 +32,12 @@ const fadeEntry = keyframes`
 `;
 
 export default function Info({ accountInfo, onSaveSuccess }: InfoProps) {
+    const alias = accountInfo?.alias || '';
+    const displayName =
+        alias && alias !== 'BATCH_RUNNER'
+            ? (localStorage.getItem(`autopcr_displayName_${alias}`) || alias)
+            : alias;
+
     const [username, setUsername] = useState<string>(accountInfo?.username);
     const [password, setPassword] = useState<string>(accountInfo?.password);
     const [channel, setChannel] = useState<string>(accountInfo?.channel);
@@ -123,7 +129,7 @@ export default function Info({ accountInfo, onSaveSuccess }: InfoProps) {
         >
              <Flex justify="space-between" align="center" mb={2}>
                 <Heading size="lg" fontWeight="bold" letterSpacing="tight">
-                    {accountInfo?.alias === 'BATCH_RUNNER' ? '批量运行配置' : accountInfo?.alias}
+                    {alias === 'BATCH_RUNNER' ? '批量运行配置' : displayName}
                 </Heading>
                 {accountInfo?.alias !== 'BATCH_RUNNER' && (
                     <Text fontSize="sm" color="fg.muted">

--- a/src/components/Account/SingleSelectModal
+++ b/src/components/Account/SingleSelectModal
@@ -1,0 +1,124 @@
+import { Box, Button, Input, Text } from '@chakra-ui/react';
+import { Candidate, ConfigValue } from '@interfaces/Module';
+import {
+    Modal,
+    ModalBody,
+    ModalCloseButton,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalOverlay,
+} from '../../components/ui/modal';
+import NiceModal, { useModal } from '@ebay/nice-modal-react';
+import { useMemo, useRef, useState } from 'react';
+
+interface SingleSelectModalProps {
+    candidates: Candidate[];
+    value: ConfigValue;
+}
+
+const singleSelectModal = NiceModal.create(({ candidates, value }: SingleSelectModalProps) => {
+    const modal = useModal();
+    const [selected, setSelected] = useState<ConfigValue>(value);
+    const [searchText, setSearchText] = useState('');
+    const lastVisibleRef = useRef(false);
+
+    if (modal.visible && !lastVisibleRef.current) {
+        setSelected(value);
+        setSearchText('');
+    }
+    lastVisibleRef.current = modal.visible;
+
+    const filtered = useMemo(() => {
+        const q = searchText.trim().toLowerCase();
+        if (!q) return candidates;
+        return candidates.filter((u) => {
+            const display = String(u.display ?? '').toLowerCase();
+            const nick = String(u.nickname ?? '').toLowerCase();
+            const val = String(u.value ?? '').toLowerCase();
+            const tags = (u.tags || []).some((t) => String(t).toLowerCase().includes(q));
+            return display.includes(q) || nick.includes(q) || val.includes(q) || tags;
+        });
+    }, [candidates, searchText]);
+
+    const handleSave = () => {
+        modal.resolve(selected);
+        void modal.hide();
+    };
+
+    const handleClose = () => {
+        modal.resolve(undefined);
+        void modal.hide();
+    };
+
+    return (
+        <Modal isOpen={modal.visible} onClose={handleClose} size="lg">
+            <ModalOverlay />
+            <ModalContent>
+                <ModalHeader>选择</ModalHeader>
+                <ModalCloseButton />
+                <ModalBody>
+                    <Input
+                        placeholder="搜索名称 / 昵称"
+                        mb={3}
+                        value={searchText}
+                        onChange={(e) => setSearchText(e.target.value)}
+                        autoFocus
+                    />
+                    <Box
+                        maxH="55vh"
+                        overflowY="auto"
+                        p={2}
+                        borderRadius="md"
+                        borderWidth="1px"
+                        borderColor="border"
+                        bg="bg.panel"
+                    >
+                        {filtered.map((u) => {
+                            const active = u.value === selected;
+                            return (
+                                <Box
+                                    key={String(u.value)}
+                                    p={2}
+                                    mb={1}
+                                    borderRadius="md"
+                                    cursor="pointer"
+                                    bg={active ? 'blue.subtle' : undefined}
+                                    fontWeight={active ? 'semibold' : 'normal'}
+                                    _hover={{ bg: active ? 'blue.subtle' : 'bg.subtle' }}
+                                    onClick={() => setSelected(u.value)}
+                                    onDoubleClick={() => {
+                                        setSelected(u.value);
+                                        modal.resolve(u.value);
+                                        void modal.hide();
+                                    }}
+                                >
+                                    {u.nickname ? u.nickname : u.display}
+                                </Box>
+                            );
+                        })}
+                        {filtered.length === 0 && (
+                            <Text color="fg.muted" fontSize="sm" py={4} textAlign="center">
+                                无匹配项
+                            </Text>
+                        )}
+                    </Box>
+                    <Text mt={2} fontSize="xs" color="fg.muted">
+                        单击选中，双击直接确认；保存后写入仍为单个值（兼容后端 single / unitchoice）
+                    </Text>
+                </ModalBody>
+                <ModalFooter>
+                    <Button onClick={handleSave} colorPalette="blue" mr={3}>
+                        保存
+                    </Button>
+                    <Button variant="ghost" onClick={handleClose}>
+                        取消
+                    </Button>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    );
+});
+
+NiceModal.register('singleSelectModal', singleSelectModal);
+export default singleSelectModal;

--- a/src/components/SideBar/Index.tsx
+++ b/src/components/SideBar/Index.tsx
@@ -45,7 +45,7 @@ const NavItem = ({ icon, children, href, onClick, ...rest }: NavItemProps) => {
             align="center"
             py={2}
             px={3}
-            borderRadius="lg"
+            borderRadius="0"
             role="group"
             cursor="pointer"
             transition="all 0.2s"
@@ -113,8 +113,8 @@ export default function Nav() {
             }
         };
 
-        eventSource.onerror = function(err) {
-            console.error('Error receiving SSE', err);
+        eventSource.onerror = function() {
+            // console.error('Error receiving SSE', err);
         };
 
         return () => {

--- a/src/components/SideBar/Index.tsx
+++ b/src/components/SideBar/Index.tsx
@@ -45,7 +45,7 @@ const NavItem = ({ icon, children, href, onClick, ...rest }: NavItemProps) => {
             align="center"
             py={2}
             px={3}
-            borderRadius="full"
+            borderRadius="lg"
             role="group"
             cursor="pointer"
             transition="all 0.2s"

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -41,7 +41,7 @@ export const ModalHeader = React.forwardRef<HTMLDivElement, React.PropsWithChild
 export const ModalBody = Dialog.Body
 export const ModalFooter = Dialog.Footer
 export const ModalCloseButton = (props: any) => (
-    <Dialog.CloseTrigger position="absolute" top="2" insetEnd="2" {...props}>
+    <Dialog.CloseTrigger asChild position="absolute" top="2" insetEnd="2" {...props}>
         <CloseButton size="sm" />
     </Dialog.CloseTrigger>
 )

--- a/src/routes/daily/_sidebar/account/$account.tsx
+++ b/src/routes/daily/_sidebar/account/$account.tsx
@@ -1,139 +1,199 @@
-import { Box, Button, Tabs } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
-import { FiStar } from 'react-icons/fi';
+import { Box, Button, HStack, Tabs, Tag } from '@chakra-ui/react';
+import { useEffect, useMemo, useState } from 'react';
+import { FiActivity, FiCheck, FiStar, FiTarget, FiUserX } from 'react-icons/fi';
 
 import { AccountResponse } from '@interfaces/Account';
 import Area from '@components/Account/Area';
-import ConfigImportExport from "@components/Account/ConfigImportExport.tsx";
+import ConfigImportExport from '@components/Account/ConfigImportExport.tsx';
 import Info from '@components/Account/Info';
 import { createFileRoute } from '@tanstack/react-router';
-import { getAccount } from '@api/Account';
+import { getAccount, postAccountAreaDaily } from '@api/Account';
+import { toaster } from '@components/ui/toaster';
 
 export const Route = createFileRoute('/daily/_sidebar/account/$account')({
     component: AccountComponent,
     loader: ({ params: { account } }) => getAccount(account),
     errorComponent: () => <div> Not Found </div>,
-})
+});
 
 function AccountComponent() {
     const { account } = Route.useParams();
     const initialAccountInfo = Route.useLoaderData<AccountResponse>();
     const [accountInfo, setAccountInfo] = useState<AccountResponse>(initialAccountInfo);
 
-    const initialTab = initialAccountInfo?.username !== '' && initialAccountInfo?.password !== '' ? "1" : "0";
-    
-    // activeTab 仅用于驱动 UI 按钮的高亮，点击瞬间 0ms 响应
-    const [activeTab, setActiveTab] = useState<string>(initialTab);
+    const initialTab =
+        initialAccountInfo?.username !== '' && initialAccountInfo?.password !== '' ? '1' : '0';
 
-    // 按 Tab 独立存储“只显示收藏”
+    const [activeTab, setActiveTab] = useState<string>(initialTab);
     const [favOnlyMap, setFavOnlyMap] = useState<Record<string, boolean>>({});
+    const [cleanLoading, setCleanLoading] = useState(false);
+
+    // 与一览一致：用清理结果的 status 驱动按钮旁徽章（不常驻死字）
+    const [cleanStatus, setCleanStatus] = useState<string>(
+        () => (initialAccountInfo as any)?.daily_clean_time?.status || '',
+    );
+
+    const [displayName, setDisplayName] = useState(
+        () => localStorage.getItem(`autopcr_displayName_${account}`) || account,
+    );
+
+    const statusMeta = useMemo(() => {
+        if (cleanStatus === '成功' || cleanStatus === '跳过') {
+            return {
+                color: 'green' as const,
+                icon: <FiCheck />,
+                label: cleanStatus === '跳过' ? '跳过' : '完成',
+            };
+        }
+        if (cleanStatus === '警告' || cleanStatus === '中止') {
+            return { color: 'orange' as const, icon: <FiActivity />, label: cleanStatus };
+        }
+        if (cleanStatus === '错误') {
+            return { color: 'red' as const, icon: <FiUserX />, label: '错误' };
+        }
+        if (cleanStatus) {
+            return { color: 'gray' as const, icon: <FiActivity />, label: cleanStatus };
+        }
+        return null;
+    }, [cleanStatus]);
 
     const refreshAccountData = async () => {
         try {
             const freshData = await getAccount(account);
             setAccountInfo(freshData);
-        } catch (error) {
-            console.error('刷新账号数据失败', error);
+            setDisplayName(localStorage.getItem(`autopcr_displayName_${account}`) || account);
+            const st = (freshData as any)?.daily_clean_time?.status;
+            if (st) setCleanStatus(st);
+        } catch (e) {
+            console.error(e);
         }
     };
 
     useEffect(() => {
-         setActiveTab(initialTab);
-     }, [initialAccountInfo, initialTab]);
+        setActiveTab(initialTab);
+        setDisplayName(localStorage.getItem(`autopcr_displayName_${account}`) || account);
+        const st = (initialAccountInfo as any)?.daily_clean_time?.status;
+        if (st) setCleanStatus(st);
+    }, [initialAccountInfo, initialTab, account]);
 
-    const activeAreaIndex = Number(activeTab) - 1;
-    const currentArea = activeTab !== "0" && accountInfo?.area ? accountInfo.area[activeAreaIndex] : null;
+    const currentArea =
+        activeTab !== '0' && accountInfo?.area
+            ? accountInfo.area[Number(activeTab) - 1]
+            : null;
     const isCurrentTabFavOnly = currentArea ? !!favOnlyMap[currentArea.key] : false;
 
     const handleToggleCurrentFavOnly = () => {
         if (!currentArea?.key) return;
-        setFavOnlyMap(prev => ({
-            ...prev,
-            [currentArea.key]: !prev[currentArea.key]
-        }));
+        setFavOnlyMap((prev) => ({ ...prev, [currentArea.key]: !prev[currentArea.key] }));
     };
 
-    const activeAreaIndex = Number(activeTab) - 1;
-    const currentArea = activeTab !== "0" && accountInfo?.area ? accountInfo.area[activeAreaIndex] : null;
-    const isCurrentTabFavOnly = currentArea ? !!favOnlyMap[currentArea.key] : false;
+    const handleCleanDaily = async () => {
+        const a = accountInfo?.alias || account;
+        const nameForUi =
+            localStorage.getItem(`autopcr_displayName_${a}`) || displayName || a;
 
-    const handleToggleCurrentFavOnly = () => {
-        if (!currentArea?.key) return;
-        setFavOnlyMap(prev => ({
-            ...prev,
-            [currentArea.key]: !prev[currentArea.key]
-        }));
+        setCleanLoading(true);
+        setCleanStatus(''); // 清理中先清掉旧徽章，结束后再按真实 status 显示
+        toaster.create({ type: 'info', title: `开始为${nameForUi}清理日常...` });
+
+        try {
+            const res = await postAccountAreaDaily(a);
+            // 与一览相同数据源：daily_clean_time.status
+            const st =
+                (res as any)?.daily_clean_time?.status ||
+                (res as any)?.status ||
+                '';
+
+            setCleanStatus(st);
+            sessionStorage.setItem('autopcr_need_refresh_dashboard', '1');
+            await refreshAccountData();
+
+            // toaster 只保留原来就能弹的那套，不另造文案体系
+            if (st === '错误') {
+                toaster.create({ type: 'error', title: `${nameForUi}清日常结束` });
+            } else if (st === '警告' || st === '中止') {
+                toaster.create({ type: 'warning', title: `${nameForUi}清日常完成(${st})` });
+            } else {
+                toaster.create({ type: 'success', title: `${nameForUi}清日常成功` });
+            }
+        } catch (err: any) {
+            setCleanStatus('错误');
+            toaster.create({
+                type: 'error',
+                title: `${nameForUi}清日常失败`,
+                description: (err?.response?.data as string) || err?.message || '网络错误',
+            });
+        } finally {
+            setCleanLoading(false);
+        }
     };
 
     return (
-        <Tabs.Root 
-            lazyMount 
-            variant="plain" 
+        <Tabs.Root
+            lazyMount
+            unmountOnExit={false}
+            variant="plain"
             value={activeTab}
-            onValueChange={(details) => setActiveTab(details.value)} // 0ms 同步高亮
-            display={'flex'} 
-            flexDirection={'column'} 
-            height={'100%'}
+            onValueChange={(d) => setActiveTab(d.value)}
+            display="flex"
+            flexDirection="column"
+            height="100%"
         >
-            <Tabs.List 
-                bg="bg.panel" 
-                p={1} 
-                borderRadius="xl" 
-                shadow="sm" 
-                borderWidth="1px" 
+            <Tabs.List
+                bg="bg.panel"
+                p={1}
+                borderRadius="xl"
+                shadow="sm"
+                borderWidth="1px"
                 borderColor="border.subtle"
                 mb={4}
                 overflowX="auto"
                 gap={1}
                 alignItems="center"
             >
-                <Tabs.Trigger 
+                <Tabs.Trigger
                     value="0"
                     px={4}
                     py={1.5}
                     rounded="lg"
                     fontWeight="semibold"
-                    transition="background-color 0.1s ease, color 0.1s ease"
-                    _selected={{ 
-                        bg: "blue.solid", 
-                        color: "white", 
-                        shadow: "md"
-                    }}
-                    _hover={{ 
-                        bg: "bg.subtle",
-                        _selected: { bg: "blue.solid", color: "white" }
-                             }}
-                > 
-                    {account} 
+                    _selected={{ bg: 'blue.solid', color: 'white', shadow: 'md' }}
+                    _hover={{ bg: 'bg.subtle', _selected: { bg: 'blue.solid', color: 'white' } }}
+                >
+                    {displayName}
                 </Tabs.Trigger>
-                
-                <Box width="1px" height="16px" alignSelf="center" bg="border.muted" mx={1} />
 
-                {accountInfo?.area.map((area, index) => (
-                    <Tabs.Trigger 
-                        value={String(index + 1)} 
+                <Box width="1px" height="1em" alignSelf="center" bg="border.muted" mx={1} />
+
+                {accountInfo?.area?.map((area, index) => (
+                    <Tabs.Trigger
                         key={area?.key}
+                        value={String(index + 1)}
                         px={3}
                         py={1.5}
                         rounded="lg"
                         fontWeight="medium"
                         color="fg.muted"
-                        transition="background-color 0.1s ease, color 0.1s ease"
-                        _selected={{ bg: "bg.subtle", color: "blue.600", fontWeight: "bold", shadow: "sm" }}
-                        _hover={{ bg: "bg.subtle", color: "fg" }}
+                        _selected={{
+                            bg: 'bg.subtle',
+                            color: 'blue.600',
+                            fontWeight: 'bold',
+                            shadow: 'sm',
+                        }}
+                        _hover={{ bg: 'bg.subtle', color: 'fg' }}
                     >
                         {area?.name}
                     </Tabs.Trigger>
                 ))}
 
-                {activeTab !== "0" && (
-                    <Box display="flex" alignItems="center" pr={2}>
+                {activeTab !== '0' && (
+                    <HStack alignItems="center" pr={2} gap={2}>
                         <Button
                             size="sm"
-                            variant={isCurrentTabFavOnly ? "solid" : "ghost"}
-                            colorPalette={isCurrentTabFavOnly ? "yellow" : "gray"}
+                            variant={isCurrentTabFavOnly ? 'solid' : 'ghost'}
+                            colorPalette={isCurrentTabFavOnly ? 'yellow' : 'gray'}
                             onClick={handleToggleCurrentFavOnly}
-                            minW="120px"
+                            minW="7.5em"
                             type="button"
                         >
                             {isCurrentTabFavOnly ? (
@@ -142,24 +202,44 @@ function AccountComponent() {
                                 <><FiStar /> 只显示收藏</>
                             )}
                         </Button>
-                    </Box>
+                        <Button
+                            size="sm"
+                            variant="ghost"
+                            colorPalette="orange"
+                            onClick={() => void handleCleanDaily()}
+                            loading={cleanLoading}
+                            type="button"
+                        >
+                            <FiTarget /> 立刻清理
+                        </Button>
+                        {/* 与一览 statusMeta 一致：出现在清理按钮右边 */}
+                        {statusMeta && (
+                            <Tag.Root size="sm" colorPalette={statusMeta.color} variant="subtle">
+                                <Tag.StartElement>{statusMeta.icon}</Tag.StartElement>
+                                <Tag.Label>{statusMeta.label}</Tag.Label>
+                            </Tag.Root>
+                        )}
+                    </HStack>
                 )}
             </Tabs.List>
 
-            <Box flex={1} overflow={'auto'}>
+            <Box flex={1} overflow="auto">
                 <Tabs.Content value="0">
                     <Info accountInfo={accountInfo} onSaveSuccess={refreshAccountData} />
-                    <ConfigImportExport alias={accountInfo?.alias} areas={accountInfo?.area} onImportSuccess={refreshAccountData} />
+                    <ConfigImportExport
+                        alias={accountInfo?.alias}
+                        areas={accountInfo?.area}
+                        onImportSuccess={refreshAccountData}
+                    />
                 </Tabs.Content>
 
-                {/* 保持静态DOM挂载逻辑，由 Tabs.Root 统一做 lazyMount 缓存 */}
-                {accountInfo?.area.map((area, index) => (
-                    <Tabs.Content value={String(index + 1)} key={area?.key}>
-                        <Area 
-                            alias={accountInfo?.alias} 
-                            keys={area?.key} 
-                            areaName={area?.name} 
-                            showOnlyFav={!!favOnlyMap[area?.key]} 
+                {accountInfo?.area?.map((area, index) => (
+                    <Tabs.Content key={area?.key} value={String(index + 1)}>
+                        <Area
+                            alias={accountInfo?.alias}
+                            keys={area?.key}
+                            areaName={area?.name}
+                            showOnlyFav={!!favOnlyMap[area?.key]}
                         />
                     </Tabs.Content>
                 ))}


### PR DESCRIPTION
## 改动说明

在不改后端 alias / 路由的前提下，优化账号一览与详情的使用体验，并改进配置项编辑与长列表选择。

### 账号一览（DashBoard）
- 支持自定义显示名（失焦保存到 localStorage，冲突校验）
- 一览展示「显示名 + 原名对照」；进详情后详情页只显示显示名
- 卡片/表格主体点击进入详情；操作按钮/删除/单选不误跳转
- 操作顺序：立刻清理 → 导入配置 → 同步配置 → 运行结果
- 清理结果按 `daily_clean_time.status` 更新状态展示（与 statusMeta 一致）
- 从详情清理返回一览时通过 sessionStorage 触发列表刷新
- 部分 Tooltip 即时显示（openDelay=0）
- 
<img width="2978" height="453" alt="image" src="https://github.com/user-attachments/assets/f00229e0-f774-4c7f-a66f-2db74bc5310b" />
<img width="741" height="614" alt="image" src="https://github.com/user-attachments/assets/8fd368c5-534c-4214-9298-f5e74e63cd6b" />
<img width="1229" height="560" alt="image" src="https://github.com/user-attachments/assets/d1a9ae57-ebf6-4086-854b-70f7fb547ddc" />
现在可以自由修改显示名。


### 账号详情（$account）
- 最左侧 Tab、账号信息标题使用显示名
- 增加「立刻清理」；清理按钮右侧展示与一览一致的状态徽章（完成/警告/中止/错误）
<img width="3752" height="526" alt="image" src="https://github.com/user-attachments/assets/a3112202-b5e2-42dc-a1a7-895fa6372cf3" />

- 右上角仍使用原有 toaster 提示（开始/成功/失败），不改 toaster 组件本身

### 配置相关（Config / Module / SingleSelectModal）
- 同一账号配置写入串行排队，降低并发保存互相覆盖的概率
- 设置项统一行高；多选保留左侧说明样式，去掉选项区多余边框
<img width="1922" height="1327" alt="image" src="https://github.com/user-attachments/assets/65d52fc7-dd34-4890-b3f2-8612f62e32c2" />
- 候选过多的 single（如 unitchoice 角色列表）改为可搜索弹窗单选，保存值仍为单个，兼容后端 single
- 
<img width="1348" height="499" alt="image" src="https://github.com/user-attachments/assets/3f8ead07-52cb-4665-b6ba-c9ac763ee306" />
<img width="1613" height="1469" alt="image" src="https://github.com/user-attachments/assets/25bcc703-8f8e-44e6-909f-e0d9b4cd9f7b" />

- 模块折叠区说明与设置项间距收紧；模块开关保存走同一串行队列

### 其它
- 弹窗关闭按钮 asChild，避免 button 嵌套告警
- 导航「一览」hover 直角
- SSE 断线重连不再刷控制台 error（功能保留）

## 涉及文件

- `src/components/Account/DashBoard.tsx`
- `src/routes/daily/_sidebar/account/$account.tsx`
- `src/components/Account/Info.tsx`
- `src/components/Account/Config.tsx`
- `src/components/Account/SingleSelectModal.tsx`（新增）
- `src/components/Account/Module.tsx`
- `src/components/ui/modal.tsx`
- `src/components/SideBar/Index.tsx`
- （若有）`ConfigImportExport.tsx` / `Area.tsx`

## 自测清单

- [ ] 一览改显示名、冲突拒绝；一览有原名对照，详情只有显示名
- [ ] 点卡片/表格进详情；点四按钮不误进详情
- [ ] 一览清理：状态徽章与 toaster 正常
- [ ] 详情清理：按钮右侧出现完成/警告/错误徽章；返回一览列表刷新
- [ ] 连续改两个配置项，刷新后都还在
- [ ] 角色类长列表可搜索选择，保存后刷新仍在
- [ ] 多选：左侧说明在，右侧无多余白边框
- [ ] 弹窗关闭无 button 嵌套警告
- [ ] 导航一览 hover 为直角