### PR TITLE
修复 折叠后打开的显示bug

### DIFF
--- a/src/components/Account/Config.tsx
+++ b/src/components/Account/Config.tsx
@@ -16,17 +16,20 @@ interface ConfigProps {
     alias: string;
     value: ConfigValue;
     info: ConfigInfo;
+    onConfigUpdate?: (key: string, value: ConfigValue) => void;
 }
 
 /**
  * 通用受控配置 Hook
  * - 管理本地 state，外部 value 变化时自动同步
  * - 提供 save 方法，带乐观更新 + 失败回滚 + 卸载保护
+ * - 保存成功后通过 onConfigUpdate 回写父级配置快照，保证折叠/重挂载后显示最新值
  */
 function useConfigState<T>(
     alias: string,
     key: string,
     propValue: T,
+    onConfigUpdate?: (key: string, value: ConfigValue) => void,
     transform?: (val: T) => ConfigValue
 ) {
     const [state, setState] = useState<T>(propValue);
@@ -48,6 +51,7 @@ function useConfigState<T>(
         const payload = transform ? transform(newValue) : (newValue as ConfigValue);
         try {
             const res = await putAccountConfig(alias, key, payload);
+            onConfigUpdate?.(key, payload);
             if (mountedRef.current) {
                 toaster.create({ type: 'success', title: '保存成功', description: res });
             }
@@ -68,8 +72,8 @@ function useConfigState<T>(
 }
 
 // ---------- ConfigBool ----------
-function ConfigBool({ alias, value, info }: ConfigProps) {
-    const [checked, , save] = useConfigState(alias, info.key, value as boolean);
+function ConfigBool({ alias, value, info, onConfigUpdate }: ConfigProps) {
+    const [checked, , save] = useConfigState(alias, info.key, value as boolean, onConfigUpdate);
 
     return (
         <InputGroup
@@ -86,7 +90,7 @@ function ConfigBool({ alias, value, info }: ConfigProps) {
 }
 
 // ---------- ConfigInt（改为 onBlur 保存）----------
-function ConfigInt({ alias, value, info }: ConfigProps) {
+function ConfigInt({ alias, value, info, onConfigUpdate }: ConfigProps) {
     const min = Math.min(...(info.candidates.map((c) => c.value) as number[]));
     const max = Math.max(...(info.candidates.map((c) => c.value) as number[]));
 
@@ -127,6 +131,7 @@ function ConfigInt({ alias, value, info }: ConfigProps) {
         const payload: ConfigValue = finalValue as ConfigValue;
         putAccountConfig(alias, info.key, payload)
             .then((res) => {
+                onConfigUpdate?.(info.key, payload);
                 if (mountedRef.current) {
                     toaster.create({ type: 'success', title: '保存成功', description: res });
                 }
@@ -165,8 +170,8 @@ function ConfigInt({ alias, value, info }: ConfigProps) {
 }
 
 // ---------- ConfigSingle ----------
-function ConfigSingle({ alias, value, info }: ConfigProps) {
-    const [selectValue, , save] = useConfigState(alias, info.key, value as string | number);
+function ConfigSingle({ alias, value, info, onConfigUpdate }: ConfigProps) {
+    const [selectValue, , save] = useConfigState(alias, info.key, value as string | number, onConfigUpdate);
 
     return (
         <InputGroup startElement={info.desc}>
@@ -196,7 +201,7 @@ function ConfigSingle({ alias, value, info }: ConfigProps) {
 }
 
 // ---------- ConfigMulti ----------
-function ConfigMulti({ alias, value, info }: ConfigProps) {
+function ConfigMulti({ alias, value, info, onConfigUpdate }: ConfigProps) {
     const initialStrArr = useMemo(
         () => (value as (string | number)[]).map(String),
         [JSON.stringify(value)]
@@ -222,6 +227,7 @@ function ConfigMulti({ alias, value, info }: ConfigProps) {
         setGroupValue(newStrArr);
         putAccountConfig(alias, info.key, postValue)
             .then((res) => {
+                onConfigUpdate?.(info.key, postValue);
                 if (mountedRef.current)
                     toaster.create({ type: 'success', title: '保存成功', description: res });
             })
@@ -271,7 +277,7 @@ function ConfigMulti({ alias, value, info }: ConfigProps) {
 }
 
 // ---------- ConfigTime ----------
-function ConfigTime({ alias, value, info }: ConfigProps) {
+function ConfigTime({ alias, value, info, onConfigUpdate }: ConfigProps) {
     const [timeStr, setTimeStr] = useState(value as string);
 
     useEffect(() => {
@@ -282,6 +288,7 @@ function ConfigTime({ alias, value, info }: ConfigProps) {
         const newValue = e.target.value;
         putAccountConfig(alias, info.key, newValue as ConfigValue)
             .then((res) => {
+                onConfigUpdate?.(info.key, newValue as ConfigValue);
                 toaster.create({ type: 'success', title: '保存成功', description: res });
             })
             .catch((err: AxiosError) => {
@@ -308,7 +315,7 @@ function ConfigTime({ alias, value, info }: ConfigProps) {
 }
 
 // ---------- ConfigText ----------
-function ConfigText({ alias, value, info }: ConfigProps) {
+function ConfigText({ alias, value, info, onConfigUpdate }: ConfigProps) {
     const [textStr, setTextStr] = useState(value as string);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -328,6 +335,7 @@ function ConfigText({ alias, value, info }: ConfigProps) {
         const newValue = e.target.value;
         putAccountConfig(alias, info.key, newValue as ConfigValue)
             .then((res) => {
+                onConfigUpdate?.(info.key, newValue as ConfigValue);
                 toaster.create({ type: 'success', title: '保存成功', description: res });
             })
             .catch((err: AxiosError) => {
@@ -355,7 +363,7 @@ function ConfigText({ alias, value, info }: ConfigProps) {
 }
 
 // ---------- ConfigMultiSearch ----------
-function ConfigMultiSearch({ alias, value, info }: ConfigProps) {
+function ConfigMultiSearch({ alias, value, info, onConfigUpdate }: ConfigProps) {
     const [localValue, setLocalValue] = useState<ConfigValue>(value);
     const mountedRef = useRef(true);
 
@@ -384,6 +392,7 @@ function ConfigMultiSearch({ alias, value, info }: ConfigProps) {
             if (ret === undefined) return;
 
             const res = await putAccountConfig(alias, info.key, ret);
+            onConfigUpdate?.(info.key, ret);
             if (mountedRef.current) {
                 setLocalValue(ret);
                 toaster.create({ type: 'success', title: '保存成功', description: res });
@@ -417,22 +426,22 @@ function ConfigMultiSearch({ alias, value, info }: ConfigProps) {
 }
 
 // ---------- 主组件 ----------
-export default function Config({ alias, value, info }: ConfigProps) {
+export default function Config({ alias, value, info, onConfigUpdate }: ConfigProps) {
     switch (info?.config_type) {
         case 'bool':
-            return <ConfigBool alias={alias} value={value} info={info} />;
+            return <ConfigBool alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         case 'int':
-            return <ConfigInt alias={alias} value={value} info={info} />;
+            return <ConfigInt alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         case 'single':
-            return <ConfigSingle alias={alias} value={value} info={info} />;
+            return <ConfigSingle alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         case 'multi':
-            return <ConfigMulti alias={alias} value={value} info={info} />;
+            return <ConfigMulti alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         case 'time':
-            return <ConfigTime alias={alias} value={value} info={info} />;
+            return <ConfigTime alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         case 'text':
-            return <ConfigText alias={alias} value={value} info={info} />;
+            return <ConfigText alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         case 'multi_search':
-            return <ConfigMultiSearch alias={alias} value={value} info={info} />;
+            return <ConfigMultiSearch alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         default:
             return null;
     }

--- a/src/components/Account/Module.tsx
+++ b/src/components/Account/Module.tsx
@@ -255,7 +255,7 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
                                         <Heading size='sm' color="fg.subtle">设置项</Heading>
                                         {
                                             info?.config_order.map((key) => (
-                                                <Config key={key} alias={alias} value={config[key]} info={info.config[key]} />
+                                                <Config key={key} alias={alias} value={config[key]} info={info.config[key]} onConfigUpdate={onConfigUpdate} />
                                             ))
                                         }
                                     </Stack>


### PR DESCRIPTION
bug具体表现为：更改配置保存之后，点击折叠选项卡，再点击显示，配置会显示成更改前的配置（实际已更改）；只有点击“一览”按钮，退出重进后才能正常显示

修复方案：补全 Area → Module → Config 回写链

改动如下：
1.Config.tsx — ConfigProps 新增 onConfigUpdate 回调；useConfigState hook 及 ConfigInt/Multi/Time/Text/MultiSearch 各控件在 PUT 成功后调用 onConfigUpdate(key, payload) 回写 Area 的配置快照，失败仍走原有本地回滚。回写调用放在 mountedRef 检查之外——即使保存后立刻折叠导致控件卸载，父级快照也能更新 
2.Module.tsx:258 — 把已有的 onConfigUpdate props 继续传给 Config