### PR TITLE
优化tab切换速度、模块折叠交互及仪表盘多选逻辑，微调了一下样式以及进入详细设置的点击范围

### DIFF
--- a/src/components/Account/Area.tsx
+++ b/src/components/Account/Area.tsx
@@ -1,11 +1,11 @@
 import { Box, Flex, IconButton, Popover, Stack, useDisclosure } from '@chakra-ui/react';
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { FiCompass } from 'react-icons/fi';
-import Module from "./Module";
+import Module from './Module';
 import { ConfigValue, ModuleResponse } from '@interfaces/Module';
 import { Skeleton } from '../../components/ui/skeleton';
-import Toc from "./Toc";
+import Toc from './Toc';
 import { getAccountConfig } from '@api/Account';
 
 interface AreaProps {
@@ -20,52 +20,97 @@ export interface TocItem {
     id: string;
 }
 
+/** 区服配置数据缓存：只存 JSON，不占 React/DOM。UI 卸载后数据仍在。 */
+const areaConfigCache = new Map<string, ModuleResponse>();
+
+function cacheKey(alias: string, key: string) {
+    return `${alias}::${key}`;
+}
+
+export function getCachedAreaConfig(alias: string, key: string) {
+    return areaConfigCache.get(cacheKey(alias, key));
+}
+
+export function setCachedAreaConfig(alias: string, key: string, data: ModuleResponse) {
+    areaConfigCache.set(cacheKey(alias, key), data);
+}
+
+/** 离开账号详情 / 导入配置成功后调用，释放该账号缓存 */
+export function clearAreaConfigCache(alias?: string) {
+    if (!alias) {
+        areaConfigCache.clear();
+        return;
+    }
+    for (const k of [...areaConfigCache.keys()]) {
+        if (k.startsWith(`${alias}::`)) areaConfigCache.delete(k);
+    }
+}
+
+function mergeFavIntoConfig(alias: string, key: string, res: ModuleResponse): ModuleResponse {
+    const favKey = `autopcr_fav_${alias}`;
+    const stored = localStorage.getItem(favKey);
+    if (!stored) return res;
+    try {
+        const favMap = JSON.parse(stored) as Record<string, string[]>;
+        const areaFavs = favMap[key] || [];
+        if (areaFavs.length === 0) return res;
+        const mergedConfig = { ...res.config };
+        areaFavs.forEach((moduleKey) => {
+            mergedConfig[`_fav_${moduleKey}`] = true;
+        });
+        return { ...res, config: mergedConfig };
+    } catch {
+        return res;
+    }
+}
+
 export default function Area({ alias, keys: key, areaName, showOnlyFav = false }: AreaProps) {
+    const cached = alias && key ? getCachedAreaConfig(alias, key) : undefined;
+
     const [state, setState] = useState<{
         config: ModuleResponse | null;
         isLoading: boolean;
-    }>({
-        config: null,
-        isLoading: true,
-    });
+    }>(() => ({
+        // 有缓存：立刻有内容，不走骨架
+        config: cached ?? null,
+        isLoading: !cached,
+    }));
 
     const { open, onOpen, onClose } = useDisclosure();
 
     useEffect(() => {
         let isMounted = true;
+        if (!alias || !key) return;
 
-        if (alias && key) {
-            getAccountConfig(alias, key)
-                .then((res) => {
-                    if (!isMounted) return;
-
-                    const favKey = `autopcr_fav_${alias}`;
-                    const stored = localStorage.getItem(favKey);
-                    let finalRes = res;
-
-                    if (stored) {
-                        try {
-                            const favMap = JSON.parse(stored) as Record<string, string[]>;
-                            const areaFavs = favMap[key] || [];
-                            const mergedConfig = { ...res.config };
-                            areaFavs.forEach((moduleKey) => {
-                                mergedConfig[`_fav_${moduleKey}`] = true;
-                            });
-                            finalRes = { ...res, config: mergedConfig };
-                        } catch {
-                            finalRes = res;
-                        }
-                    }
-
-                    setState({ config: finalRes, isLoading: false });
-                })
-                .catch((err) => {
-                    if (isMounted) {
-                        console.error(err);
-                        setState((prev) => ({ ...prev, isLoading: false }));
-                    }
-                });
+        // 已有缓存：只恢复 UI，不再请求（改过的设置已在 handleConfigUpdate 写回缓存）
+        const hit = getCachedAreaConfig(alias, key);
+        if (hit) {
+            // 收藏可能在别处改过，再合并一次 localStorage（极轻）
+            const withFav = mergeFavIntoConfig(alias, key, hit);
+            if (withFav !== hit) {
+                setCachedAreaConfig(alias, key, withFav);
+            }
+            setState({ config: withFav, isLoading: false });
+            return () => {
+                isMounted = false;
+            };
         }
+
+        setState({ config: null, isLoading: true });
+
+        getAccountConfig(alias, key)
+            .then((res) => {
+                if (!isMounted) return;
+                const finalRes = mergeFavIntoConfig(alias, key, res);
+                setCachedAreaConfig(alias, key, finalRes);
+                setState({ config: finalRes, isLoading: false });
+            })
+            .catch((err) => {
+                if (isMounted) {
+                    console.error(err);
+                    setState((prev) => ({ ...prev, isLoading: false }));
+                }
+            });
 
         return () => {
             isMounted = false;
@@ -75,13 +120,15 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
     const handleConfigUpdate = (configKey: string, value: ConfigValue) => {
         setState((prev) => {
             if (!prev.config) return prev;
-            return {
-                ...prev,
-                config: {
-                    ...prev.config,
-                    config: { ...prev.config.config, [configKey]: value },
-                },
+            const nextConfig: ModuleResponse = {
+                ...prev.config,
+                config: { ...prev.config.config, [configKey]: value },
             };
+            // 同步写缓存：切走再回来设置还在，无需重新拉
+            if (alias && key) {
+                setCachedAreaConfig(alias, key, nextConfig);
+            }
+            return { ...prev, config: nextConfig };
         });
     };
 
@@ -145,7 +192,7 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
 
             <Flex
                 position="fixed"
-                right={{ base: "3", md: "6" }}
+                right={{ base: '3', md: '6' }}
                 top="50%"
                 transform="translateY(-50%)"
                 justifyContent="center"
@@ -157,11 +204,11 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
                         <IconButton
                             aria-label="TOC"
                             colorPalette="blue"
-                            size={{ base: "lg", md: "xl" }}
+                            size={{ base: 'lg', md: 'xl' }}
                             rounded="full"
                             shadow="xl"
                             transition="transform 0.2s ease"
-                            _hover={{ transform: "scale(1.1)", shadow: "2xl" }}
+                            _hover={{ transform: 'scale(1.1)', shadow: '2xl' }}
                         >
                             <FiCompass />
                         </IconButton>

--- a/src/components/Account/Area.tsx
+++ b/src/components/Account/Area.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, IconButton, Popover, Stack, useDisclosure } from '@chakra-ui/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { FiCompass } from 'react-icons/fi';
 import Module from './Module';
@@ -7,6 +7,7 @@ import { ConfigValue, ModuleResponse } from '@interfaces/Module';
 import { Skeleton } from '../../components/ui/skeleton';
 import Toc from './Toc';
 import { getAccountConfig } from '@api/Account';
+import { toaster } from '../../components/ui/toaster';
 
 interface AreaProps {
     alias: string;
@@ -71,7 +72,6 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
         config: ModuleResponse | null;
         isLoading: boolean;
     }>(() => ({
-        // 有缓存：立刻有内容，不走骨架
         config: cached ?? null,
         isLoading: !cached,
     }));
@@ -82,10 +82,8 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
         let isMounted = true;
         if (!alias || !key) return;
 
-        // 已有缓存：只恢复 UI，不再请求（改过的设置已在 handleConfigUpdate 写回缓存）
         const hit = getCachedAreaConfig(alias, key);
         if (hit) {
-            // 收藏可能在别处改过，再合并一次 localStorage（极轻）
             const withFav = mergeFavIntoConfig(alias, key, hit);
             if (withFav !== hit) {
                 setCachedAreaConfig(alias, key, withFav);
@@ -109,6 +107,11 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
                 if (isMounted) {
                     console.error(err);
                     setState((prev) => ({ ...prev, isLoading: false }));
+                    toaster.create({
+                        type: 'error',
+                        title: '加载配置失败',
+                        description: '请检查网络后重新进入该区服',
+                    });
                 }
             });
 
@@ -117,20 +120,22 @@ export default function Area({ alias, keys: key, areaName, showOnlyFav = false }
         };
     }, [alias, key]);
 
-    const handleConfigUpdate = (configKey: string, value: ConfigValue) => {
+    const handleConfigUpdate = useCallback((configKey: string, value: ConfigValue) => {
         setState((prev) => {
             if (!prev.config) return prev;
             const nextConfig: ModuleResponse = {
                 ...prev.config,
                 config: { ...prev.config.config, [configKey]: value },
             };
-            // 同步写缓存：切走再回来设置还在，无需重新拉
-            if (alias && key) {
-                setCachedAreaConfig(alias, key, nextConfig);
-            }
             return { ...prev, config: nextConfig };
         });
-    };
+    }, []);
+
+    // state.config 变化时同步到会话缓存（离开区服 UI 后仍能秒开且带最新改动）
+    useEffect(() => {
+        if (!alias || !key || !state.config) return;
+        setCachedAreaConfig(alias, key, state.config);
+    }, [alias, key, state.config]);
 
     const config = state.config;
 

--- a/src/components/Account/Config.tsx
+++ b/src/components/Account/Config.tsx
@@ -26,6 +26,8 @@ interface ConfigProps {
     alias: string;
     value: ConfigValue;
     info: ConfigInfo;
+    /** 回写父级 Area；折叠卸载后再展开必须靠它 */
+    onConfigUpdate?: (key: string, value: ConfigValue) => void;
 }
 
 const configSaveChains = new Map<string, Promise<unknown>>();
@@ -43,6 +45,32 @@ export function enqueueConfigSave<T>(alias: string, task: () => Promise<T>): Pro
     return next;
 }
 
+/** 安全解析后端错误文案，避免 Blob/.text 抛错或 [object Object] */
+export async function getErrorDescription(err: unknown, fallback = '网络错误'): Promise<string> {
+    const data = (err as { response?: { data?: unknown } })?.response?.data;
+    try {
+        if (data == null) {
+            if (err instanceof Error && err.message) return err.message;
+            return fallback;
+        }
+        if (typeof Blob !== 'undefined' && data instanceof Blob) {
+            const t = await data.text();
+            return t || fallback;
+        }
+        if (typeof data === 'string') return data || fallback;
+        if (typeof data === 'object') {
+            try {
+                return JSON.stringify(data);
+            } catch {
+                return fallback;
+            }
+        }
+        return String(data);
+    } catch {
+        return fallback;
+    }
+}
+
 const ROW_H = '2.25rem';
 const SINGLE_SEARCH_THRESHOLD = 30;
 
@@ -50,10 +78,15 @@ function useConfigState<T>(
     alias: string,
     key: string,
     propValue: T,
+    onConfigUpdate?: (key: string, value: ConfigValue) => void,
     transform?: (val: T) => ConfigValue,
 ) {
     const [state, setState] = useState<T>(propValue);
     const mountedRef = useRef(true);
+    const propRef = useRef(propValue);
+    propRef.current = propValue;
+    const onUpdateRef = useRef(onConfigUpdate);
+    onUpdateRef.current = onConfigUpdate;
 
     useEffect(() => {
         setState(propValue);
@@ -69,19 +102,22 @@ function useConfigState<T>(
     const save = async (newValue: T): Promise<void> => {
         setState(newValue);
         const payload = transform ? transform(newValue) : (newValue as ConfigValue);
+        // 先写父级缓存，折叠/切 Tab 再展开仍是新值
+        onUpdateRef.current?.(key, payload);
         try {
             const res = await enqueueConfigSave(alias, () => putAccountConfig(alias, key, payload));
             if (mountedRef.current) {
                 toaster.create({ type: 'success', title: '保存成功', description: res });
             }
         } catch (err) {
-            const axiosErr = err as AxiosError;
+            const rollback = propRef.current;
+            onUpdateRef.current?.(key, rollback as ConfigValue);
             if (mountedRef.current) {
-                setState(propValue);
+                setState(rollback);
                 toaster.create({
                     type: 'error',
                     title: '保存失败',
-                    description: (axiosErr.response?.data as string) || '网络错误',
+                    description: await getErrorDescription(err),
                 });
             }
         }
@@ -90,8 +126,9 @@ function useConfigState<T>(
     return [state, setState, save] as const;
 }
 
-function ConfigBool({ alias, value, info }: ConfigProps) {
-    const [checked, , save] = useConfigState(alias, info.key, value as boolean);
+
+function ConfigBool({ alias, value, info, onConfigUpdate }: ConfigProps) {
+    const [checked, , save] = useConfigState(alias, info.key, value as boolean, onConfigUpdate);
 
     return (
         <InputGroup
@@ -111,12 +148,17 @@ function ConfigBool({ alias, value, info }: ConfigProps) {
     );
 }
 
-function ConfigInt({ alias, value, info }: ConfigProps) {
-    const min = Math.min(...(info.candidates.map((c) => c.value) as number[]));
-    const max = Math.max(...(info.candidates.map((c) => c.value) as number[]));
+function ConfigInt({ alias, value, info, onConfigUpdate }: ConfigProps) {
+    const candNums = (info.candidates || []).map((c) => c.value).filter((v): v is number => typeof v === 'number' && !isNaN(v));
+    const min = candNums.length ? Math.min(...candNums) : 0;
+    const max = candNums.length ? Math.max(...candNums) : Number.MAX_SAFE_INTEGER;
 
     const [numStr, setNumStr] = useState(String(value));
     const mountedRef = useRef(true);
+    const valueRef = useRef(value);
+    valueRef.current = value;
+    const onUpdateRef = useRef(onConfigUpdate);
+    onUpdateRef.current = onConfigUpdate;
 
     useEffect(() => {
         setNumStr(String(value));
@@ -139,6 +181,7 @@ function ConfigInt({ alias, value, info }: ConfigProps) {
         if (finalValue < min) finalValue = min;
         if (finalValue > max) finalValue = max;
         setNumStr(String(finalValue));
+        onUpdateRef.current?.(info.key, finalValue as ConfigValue);
 
         enqueueConfigSave(alias, () => putAccountConfig(alias, info.key, finalValue as ConfigValue))
             .then((res) => {
@@ -146,13 +189,15 @@ function ConfigInt({ alias, value, info }: ConfigProps) {
                     toaster.create({ type: 'success', title: '保存成功', description: res });
                 }
             })
-            .catch((err: AxiosError) => {
+            .catch(async (err: AxiosError) => {
+                const rollback = valueRef.current;
+                onUpdateRef.current?.(info.key, rollback as ConfigValue);
                 if (mountedRef.current) {
-                    setNumStr(String(value));
+                    setNumStr(String(rollback));
                     toaster.create({
                         type: 'error',
                         title: '保存失败',
-                        description: (err.response?.data as string) || '网络错误',
+                        description: await getErrorDescription(err),
                     });
                 }
             });
@@ -210,9 +255,12 @@ function ConfigInt({ alias, value, info }: ConfigProps) {
     );
 }
 
-function ConfigSingleSearch({ alias, value, info }: ConfigProps) {
+
+function ConfigSingleSearch({ alias, value, info, onConfigUpdate }: ConfigProps) {
     const [localValue, setLocalValue] = useState<ConfigValue>(value);
     const mountedRef = useRef(true);
+    const onUpdateRef = useRef(onConfigUpdate);
+    onUpdateRef.current = onConfigUpdate;
 
     useEffect(() => {
         setLocalValue(value);
@@ -245,19 +293,22 @@ function ConfigSingleSearch({ alias, value, info }: ConfigProps) {
             })) as ConfigValue | undefined;
             if (ret === undefined) return;
 
+            // 乐观更新显示，失败再回滚
+            setLocalValue(ret);
+            onUpdateRef.current?.(info.key, ret);
             const res = await enqueueConfigSave(alias, () => putAccountConfig(alias, info.key, ret));
             if (mountedRef.current) {
-                setLocalValue(ret);
                 toaster.create({ type: 'success', title: '保存成功', description: res });
             }
         } catch (err) {
-            const axiosErr = err as AxiosError;
+            onUpdateRef.current?.(info.key, previousValue);
+            try { await NiceModal.hide(singleSelectModal); } catch { /* ignore */ }
             if (mountedRef.current) {
                 setLocalValue(previousValue);
                 toaster.create({
                     type: 'error',
                     title: '保存失败',
-                    description: (axiosErr.response?.data as string) || '网络错误',
+                    description: await getErrorDescription(err),
                 });
             }
         }
@@ -280,12 +331,8 @@ function ConfigSingleSearch({ alias, value, info }: ConfigProps) {
     );
 }
 
-function ConfigSingle({ alias, value, info }: ConfigProps) {
-    if ((info.candidates?.length || 0) >= SINGLE_SEARCH_THRESHOLD) {
-        return <ConfigSingleSearch alias={alias} value={value} info={info} />;
-    }
-
-    const [selectValue, , save] = useConfigState(alias, info.key, value as string | number);
+function ConfigSingleSelect({ alias, value, info, onConfigUpdate }: ConfigProps) {
+    const [selectValue, , save] = useConfigState(alias, info.key, value as string | number, onConfigUpdate);
 
     return (
         <InputGroup w="1/4" minH={ROW_H} alignItems="center" startElement={info.desc}>
@@ -315,7 +362,16 @@ function ConfigSingle({ alias, value, info }: ConfigProps) {
     );
 }
 
-function ConfigMulti({ alias, value, info }: ConfigProps) {
+/** 路由组件：条件分支里不调用 Hook，避免违反 Rules of Hooks */
+function ConfigSingle(props: ConfigProps) {
+    if ((props.info.candidates?.length || 0) >= SINGLE_SEARCH_THRESHOLD) {
+        return <ConfigSingleSearch {...props} />;
+    }
+    return <ConfigSingleSelect {...props} />;
+}
+
+
+function ConfigMulti({ alias, value, info, onConfigUpdate }: ConfigProps) {
     const initialStrArr = useMemo(
         () => (value as (string | number)[]).map(String),
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -324,6 +380,10 @@ function ConfigMulti({ alias, value, info }: ConfigProps) {
 
     const [groupValue, setGroupValue] = useState(initialStrArr);
     const mountedRef = useRef(true);
+    const onUpdateRef = useRef(onConfigUpdate);
+    onUpdateRef.current = onConfigUpdate;
+    const initialRef = useRef(initialStrArr);
+    initialRef.current = initialStrArr;
 
     useEffect(() => {
         setGroupValue(initialStrArr);
@@ -339,22 +399,28 @@ function ConfigMulti({ alias, value, info }: ConfigProps) {
     const handleSave = (newStrArr: string[]) => {
         let postValue: ConfigValue = newStrArr;
         const intArr = newStrArr.map(Number);
-        if (intArr.length > 0 && !isNaN(intArr[0])) postValue = intArr;
+        if (intArr.length > 0 && intArr.every((n) => !isNaN(n))) postValue = intArr;
 
         setGroupValue(newStrArr);
+        onUpdateRef.current?.(info.key, postValue);
         enqueueConfigSave(alias, () => putAccountConfig(alias, info.key, postValue))
             .then((res) => {
                 if (mountedRef.current) {
                     toaster.create({ type: 'success', title: '保存成功', description: res });
                 }
             })
-            .catch((err: AxiosError) => {
+            .catch(async (err: AxiosError) => {
+                const rollback = initialRef.current;
+                let rollbackPayload: ConfigValue = rollback;
+                const ints = rollback.map(Number);
+                if (ints.length > 0 && ints.every((n) => !isNaN(n))) rollbackPayload = ints;
+                onUpdateRef.current?.(info.key, rollbackPayload);
                 if (mountedRef.current) {
-                    setGroupValue(initialStrArr);
+                    setGroupValue(rollback);
                     toaster.create({
                         type: 'error',
                         title: '保存失败',
-                        description: (err.response?.data as string) || '网络错误',
+                        description: await getErrorDescription(err),
                     });
                 }
             });
@@ -386,9 +452,14 @@ function ConfigMulti({ alias, value, info }: ConfigProps) {
     );
 }
 
-function ConfigTime({ alias, value, info }: ConfigProps) {
+
+function ConfigTime({ alias, value, info, onConfigUpdate }: ConfigProps) {
     const [timeStr, setTimeStr] = useState(value as string);
     const mountedRef = useRef(true);
+    const valueRef = useRef(value);
+    valueRef.current = value;
+    const onUpdateRef = useRef(onConfigUpdate);
+    onUpdateRef.current = onConfigUpdate;
 
     useEffect(() => {
         setTimeStr(value as string);
@@ -403,19 +474,22 @@ function ConfigTime({ alias, value, info }: ConfigProps) {
 
     const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
         const newValue = e.target.value;
+        onUpdateRef.current?.(info.key, newValue as ConfigValue);
         enqueueConfigSave(alias, () => putAccountConfig(alias, info.key, newValue as ConfigValue))
             .then((res) => {
                 if (mountedRef.current) {
                     toaster.create({ type: 'success', title: '保存成功', description: res });
                 }
             })
-            .catch((err: AxiosError) => {
+            .catch(async (err: AxiosError) => {
+                const rollback = valueRef.current as string;
+                onUpdateRef.current?.(info.key, rollback as ConfigValue);
                 if (mountedRef.current) {
-                    setTimeStr(value as string);
+                    setTimeStr(rollback);
                     toaster.create({
                         type: 'error',
                         title: '保存失败',
-                        description: (err.response?.data as string) || '网络错误',
+                        description: await getErrorDescription(err),
                     });
                 }
             });
@@ -436,10 +510,15 @@ function ConfigTime({ alias, value, info }: ConfigProps) {
     );
 }
 
-function ConfigText({ alias, value, info }: ConfigProps) {
+
+function ConfigText({ alias, value, info, onConfigUpdate }: ConfigProps) {
     const [textStr, setTextStr] = useState(value as string);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const mountedRef = useRef(true);
+    const valueRef = useRef(value);
+    valueRef.current = value;
+    const onUpdateRef = useRef(onConfigUpdate);
+    onUpdateRef.current = onConfigUpdate;
 
     useEffect(() => {
         setTextStr(value as string);
@@ -462,19 +541,22 @@ function ConfigText({ alias, value, info }: ConfigProps) {
 
     const handleBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => {
         const newValue = e.target.value;
+        onUpdateRef.current?.(info.key, newValue as ConfigValue);
         enqueueConfigSave(alias, () => putAccountConfig(alias, info.key, newValue as ConfigValue))
             .then((res) => {
                 if (mountedRef.current) {
                     toaster.create({ type: 'success', title: '保存成功', description: res });
                 }
             })
-            .catch((err: AxiosError) => {
+            .catch(async (err: AxiosError) => {
+                const rollback = valueRef.current as string;
+                onUpdateRef.current?.(info.key, rollback as ConfigValue);
                 if (mountedRef.current) {
-                    setTextStr(value as string);
+                    setTextStr(rollback);
                     toaster.create({
                         type: 'error',
                         title: '保存失败',
-                        description: (err.response?.data as string) || '网络错误',
+                        description: await getErrorDescription(err),
                     });
                 }
             });
@@ -497,9 +579,12 @@ function ConfigText({ alias, value, info }: ConfigProps) {
     );
 }
 
-function ConfigMultiSearch({ alias, value, info }: ConfigProps) {
+
+function ConfigMultiSearch({ alias, value, info, onConfigUpdate }: ConfigProps) {
     const [localValue, setLocalValue] = useState<ConfigValue>(value);
     const mountedRef = useRef(true);
+    const onUpdateRef = useRef(onConfigUpdate);
+    onUpdateRef.current = onConfigUpdate;
 
     useEffect(() => {
         setLocalValue(value);
@@ -527,20 +612,22 @@ function ConfigMultiSearch({ alias, value, info }: ConfigProps) {
             })) as ConfigValue;
             if (ret === undefined) return;
 
+            // show 关闭后已 resolve，成功路径不要再 hide，否则可能进 catch 误回滚
+            setLocalValue(ret);
+            onUpdateRef.current?.(info.key, ret);
             const res = await enqueueConfigSave(alias, () => putAccountConfig(alias, info.key, ret));
             if (mountedRef.current) {
-                setLocalValue(ret);
                 toaster.create({ type: 'success', title: '保存成功', description: res });
             }
-            await NiceModal.hide(multiSelectModal);
         } catch (err) {
-            const axiosErr = err as AxiosError;
+            onUpdateRef.current?.(info.key, previousValue);
+            try { await NiceModal.hide(multiSelectModal); } catch { /* ignore */ }
             if (mountedRef.current) {
                 setLocalValue(previousValue);
                 toaster.create({
                     type: 'error',
                     title: '保存失败',
-                    description: (axiosErr.response?.data as string) || '网络错误',
+                    description: await getErrorDescription(err),
                 });
             }
         }
@@ -569,22 +656,22 @@ function ConfigMultiSearch({ alias, value, info }: ConfigProps) {
     );
 }
 
-export default function Config({ alias, value, info }: ConfigProps) {
+export default function Config({ alias, value, info, onConfigUpdate }: ConfigProps) {
     switch (info?.config_type) {
         case 'bool':
-            return <ConfigBool alias={alias} value={value} info={info} />;
+            return <ConfigBool alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         case 'int':
-            return <ConfigInt alias={alias} value={value} info={info} />;
+            return <ConfigInt alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         case 'single':
-            return <ConfigSingle alias={alias} value={value} info={info} />;
+            return <ConfigSingle alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         case 'multi':
-            return <ConfigMulti alias={alias} value={value} info={info} />;
+            return <ConfigMulti alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         case 'time':
-            return <ConfigTime alias={alias} value={value} info={info} />;
+            return <ConfigTime alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         case 'text':
-            return <ConfigText alias={alias} value={value} info={info} />;
+            return <ConfigText alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         case 'multi_search':
-            return <ConfigMultiSearch alias={alias} value={value} info={info} />;
+            return <ConfigMultiSearch alias={alias} value={value} info={info} onConfigUpdate={onConfigUpdate} />;
         default:
             return null;
     }

--- a/src/components/Account/DashBoard.tsx
+++ b/src/components/Account/DashBoard.tsx
@@ -14,7 +14,6 @@ import {
     Text,
 } from '@chakra-ui/react';
 import { FiActivity, FiBook, FiCheck, FiCopy, FiGrid, FiKey, FiLayers, FiList, FiStar, FiTarget, FiUpload, FiUserMinus, FiUserPlus, FiUserX, FiX } from 'react-icons/fi';
-import { Radio, RadioGroup } from '../../components/ui/radio';
 import React, { ChangeEvent, useMemo, useRef } from 'react';
 import { Skeleton, SkeletonText } from '../../components/ui/skeleton';
 import { clearAccounts, deleteAccount, getAccountDailyResultList, getUserInfo, putUserInfo } from '@api/Account';
@@ -109,14 +108,35 @@ export function DashBoard() {
     }, [freshAccountInfo.open]);
 
     const handleDefaultAccount = (value: string) => {
+        // 后端 put_info 仅在非空时写入；清空依赖后端接受空串（见 README）
         putUserInfo({ default_account: value })
             .then((res) => {
-                setUserInfo({ ...userInfo, default_account: value });
-                toaster.create({ type: 'success', title: '设置默认账号成功', description: res });
+                setUserInfo((prev) => (prev ? { ...prev, default_account: value } : prev));
+                toaster.create({
+                    type: 'success',
+                    title: value ? '设置默认账号成功' : '已取消默认账号',
+                    description: res,
+                });
             })
             .catch((err: AxiosError) => {
-                toaster.create({ type: 'error', title: '设置默认账号失败', description: (err?.response?.data as string) || '网络错误' });
+                toaster.create({
+                    type: 'error',
+                    title: value ? '设置默认账号失败' : '取消默认账号失败',
+                    description: (err?.response?.data as string) || '网络错误',
+                });
             });
+    };
+
+    const singleSelected = selectedAccounts.length === 1 ? selectedAccounts[0] : '';
+    const singleIsDefault = !!singleSelected && userInfo?.default_account === singleSelected;
+
+    const handleToggleDefaultForSelected = () => {
+        if (!singleSelected) return;
+        if (singleIsDefault) {
+            handleDefaultAccount('');
+        } else {
+            handleDefaultAccount(singleSelected);
+        }
     };
 
     const handleResetPassword = () => {
@@ -158,7 +178,7 @@ export function DashBoard() {
     };
 
     const handleCleanDailyAll = () => {
-        if (isTableView && selectedAccounts.length > 0) {
+        if (selectedAccounts.length > 0) {
             for (const accountName of selectedAccounts) {
                 const fn = handle.get(accountName);
                 if (fn) fn(false);
@@ -323,7 +343,7 @@ export function DashBoard() {
                         onClick={handleCleanDailyAll}
                         loading={count != 0}
                     >
-                        <FiTarget /> {isTableView && selectedAccounts.length > 0 ? `清选择(${selectedAccounts.length})` : '清理全部'}
+                        <FiTarget /> {selectedAccounts.length > 0 ? `清选择(${selectedAccounts.length})` : '清理全部'}
                     </Button>
                     <Button
                         as={Link}
@@ -372,27 +392,39 @@ export function DashBoard() {
                         </Tooltip>
                     </Box>
 
-                    {isTableView && selectedAccounts.length === 1 && (
+                    {singleSelected && (
                         <HStack gap={1} separator={<Box w="1px" h="15px" bg="border.subtle" />}>
-                             <Tooltip content={`将其他账号配置同步为 ${selectedAccounts[0]} 的配置`} openDelay={0} closeDelay={0}>
+                            <Tooltip content={`将其他账号配置同步为 ${singleSelected} 的配置`} openDelay={0} closeDelay={0}>
                                 <IconButton
                                     aria-label="Sync configuration"
                                     size="sm"
                                     variant="ghost"
                                     colorPalette="teal"
                                     onClick={() => {
-                                        NiceModal.show(ConfigSyncModal, { sourceAccount: selectedAccounts[0] });
+                                        NiceModal.show(ConfigSyncModal, { sourceAccount: singleSelected });
                                     }}
-                                > <FiCopy /> </IconButton>
+                                >
+                                    <FiCopy />
+                                </IconButton>
                             </Tooltip>
-                            <Tooltip content={`将 ${selectedAccounts[0]} 设为默认账号`}  openDelay={0} closeDelay={0}>
+                            <Tooltip
+                                content={
+                                    singleIsDefault
+                                        ? `取消 ${singleSelected} 的默认账号`
+                                        : `将 ${singleSelected} 设为默认账号`
+                                }
+                                openDelay={0}
+                                closeDelay={0}
+                            >
                                 <IconButton
-                                    aria-label="Set as default"
+                                    aria-label={singleIsDefault ? 'Unset default' : 'Set as default'}
                                     size="sm"
-                                    variant="ghost"
+                                    variant={singleIsDefault ? 'solid' : 'ghost'}
                                     colorPalette="purple"
-                                    onClick={() => handleDefaultAccount(selectedAccounts[0])}
-                                > <FiStar /> </IconButton>
+                                    onClick={handleToggleDefaultForSelected}
+                                >
+                                    <FiStar />
+                                </IconButton>
                             </Tooltip>
                         </HStack>
                     )}
@@ -417,14 +449,14 @@ export function DashBoard() {
                             display="none"
                         />
 
-                         <Tooltip content={isTableView && selectedAccounts.length > 0 ? `删除选中(${selectedAccounts.length})` : '删除全部'}  openDelay={0} closeDelay={0}>
+                         <Tooltip content={selectedAccounts.length > 0 ? `删除选中(${selectedAccounts.length})` : '删除全部'}  openDelay={0} closeDelay={0}>
                             <IconButton
                                 aria-label="Delete selected accounts"
                                 size="sm"
                                 variant="outline"
                                 colorPalette="red"
                                 onClick={() => {
-                                    if (isTableView && selectedAccounts.length > 0) {
+                                    if (selectedAccounts.length > 0) {
                                         if (window.confirm(`确定删除选中的 ${selectedAccounts.length} 个账号吗？`)) {
                                             Promise.all(selectedAccounts.map((name) => delAccount(name)))
                                                 .then(() => {
@@ -494,7 +526,7 @@ export function DashBoard() {
                     <Table.Root variant="outline" colorPalette="blue" size="sm" bg="bg.panel" borderRadius="xl" boxShadow="sm" ml="0" mr="auto">
                         <Table.Header position="sticky" top={0} bg="bg.subtle" zIndex={1} boxShadow="sm">
                             <Table.Row>
-                                <Table.ColumnHeader px={3} fontSize="md" py={4} fontWeight="bold" width="5%">
+                                <Table.ColumnHeader px={5} fontSize="md" py={4} fontWeight="bold" width="0%">
                                     <Checkbox
                                         checked={
                                             (selectedAccounts.length > 0 && selectedAccounts.length < (userInfo?.accounts?.length ?? 0))
@@ -503,6 +535,14 @@ export function DashBoard() {
                                         }
                                         onCheckedChange={toggleSelectAll}
                                         colorPalette="blue"
+                                        size="md"
+                                        css={{
+                                            '& [data-part=control], & .chakra-checkbox__control': {
+                                                borderRadius: '9999px',
+                                                width: '1.25rem',
+                                                height: '1.25rem',
+                                            },
+                                        }}
                                     />
                                 </Table.ColumnHeader>
                                 <Table.ColumnHeader px={0} fontSize="md" py={4} fontWeight="bold" width="25%" minWidth="80px">
@@ -550,41 +590,38 @@ export function DashBoard() {
                     </Table.Root>
                 </Box>
             ) : (
-                <RadioGroup onValueChange={(e) => handleDefaultAccount(e.value || "")} value={userInfo?.default_account} flex={1} overflow={'auto'} p={1}>
-                    <Stack>
-                        <SimpleGrid gap={4} templateColumns="repeat(auto-fill, minmax(280px, 1fr))">
-                            {!userInfo ? (
-                                Array.from({ length: 4 }).map((_, i) => (
-                                    <Card.Root key={i} bg="bg.panel" borderRadius="2xl" shadow="sm">
-                                        <Card.Header><Skeleton height="24px" width="50%" /></Card.Header>
-                                        <Card.Body><SkeletonText noOfLines={3} gap={4} /></Card.Body>
-                                        <Card.Footer><Skeleton height="32px" width="100%" /></Card.Footer>
-                                    </Card.Root>
-                                ))
-                            ) : (
-                                userInfo?.accounts?.map((account) => {
-                                    return (
-                                        <AccountInfo
-                                            key={account.name}
-                                            account={account}
-                                            onToggle={freshAccountInfo.onToggle}
-                                            increaseCount={increaseCount}
-                                            decreaseCount={decreaseCount}
-                                            updateAccountInfo={updateAccountInfo}
-                                            isTableView={isTableView}
-                                            isSelected={selectedAccounts.includes(account.name)}
-                                            onToggleSelect={() => toggleSelectAccount(account.name)}
-                                            getOccupiedNames={occupiedNamesFactory}
-                                            onOpenSyncConfig={(a) => {
-                                                NiceModal.show(ConfigSyncModal, { sourceAccount: a });
-                                            }}
-                                        />
-                                    );
-                                })
-                            )}
-                        </SimpleGrid>
-                    </Stack>
-                </RadioGroup>
+                <Box flex={1} overflow={'auto'} p={1}>
+                    <SimpleGrid gap={4} templateColumns="repeat(auto-fill, minmax(280px, 1fr))">
+                        {!userInfo ? (
+                            Array.from({ length: 4 }).map((_, i) => (
+                                <Card.Root key={i} bg="bg.panel" borderRadius="2xl" shadow="sm">
+                                    <Card.Header><Skeleton height="24px" width="50%" /></Card.Header>
+                                    <Card.Body><SkeletonText noOfLines={3} gap={4} /></Card.Body>
+                                    <Card.Footer><Skeleton height="32px" width="100%" /></Card.Footer>
+                                </Card.Root>
+                            ))
+                        ) : (
+                            userInfo?.accounts?.map((account) => (
+                                <AccountInfo
+                                    key={account.name}
+                                    account={account}
+                                    onToggle={freshAccountInfo.onToggle}
+                                    increaseCount={increaseCount}
+                                    decreaseCount={decreaseCount}
+                                    updateAccountInfo={updateAccountInfo}
+                                    isTableView={isTableView}
+                                    isSelected={selectedAccounts.includes(account.name)}
+                                    onToggleSelect={() => toggleSelectAccount(account.name)}
+                                    defaultAccount={userInfo?.default_account}
+                                    getOccupiedNames={occupiedNamesFactory}
+                                    onOpenSyncConfig={(a) => {
+                                        NiceModal.show(ConfigSyncModal, { sourceAccount: a });
+                                    }}
+                                />
+                            ))
+                        )}
+                    </SimpleGrid>
+                </Box>
             )}
         </Stack>
     );
@@ -678,7 +715,14 @@ function AccountInfo({
         }
     };
 
-    handle.set(account.name, handleCleanDaily);
+    // 批量清理用：只在 alias/显示名变化时注册，卸载时删掉
+    useEffect(() => {
+        handle.set(alias, handleCleanDaily as any);
+        return () => {
+            handle.delete(alias);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [alias, displayName]);
 
     const handleDeleteAccount = () => {
         delAccount(alias)
@@ -715,27 +759,9 @@ function AccountInfo({
         void navigate({ to: `${DashBoardRoute.to || ''}${alias}` as any });
     };
 
-    const nameInputRef = useRef<HTMLInputElement>(null);
-
-    const startEditName = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        setNameDraft(displayName);
-        setIsEditingName(true);
-    };
-
-    useEffect(() => {
-        if (!isEditingName) return;
-        const el = nameInputRef.current;
-        if (!el) return;
-        el.focus();
-        // 光标放到末尾，避免整段被选中
-        const len = el.value.length;
-        el.setSelectionRange(len, len);
-    }, [isEditingName]);
-
     const commitDisplayName = () => {
         const next = nameDraft.trim();
-        // 空或改回原始 alias → 清除自定义显示名
+        // 空名 / 等于真实 alias：恢复为 alias
         if (!next || next === alias) {
             localStorage.removeItem(DISPLAY_NAME_KEY(alias));
             setDisplayName(alias);
@@ -743,13 +769,8 @@ function AccountInfo({
             setIsEditingName(false);
             return;
         }
-        // 没改
-        if (next === displayName) {
-            setIsEditingName(false);
-            return;
-        }
         const occupied = getOccupiedNames(alias);
-        if (occupied.has(next)) {
+        if (occupied.has(next) && next !== displayName) {
             toaster.create({
                 type: 'error',
                 title: '显示名冲突',
@@ -764,17 +785,20 @@ function AccountInfo({
         setIsEditingName(false);
     };
 
-    // 始终同一 Input：展示/编辑同一位置，避免 Text→Input 错位
+    // 始终同一 Input：可编辑区域与名字位置重合
     const nameInput = (
         <Input
-            ref={nameInputRef}
             size="sm"
             value={isEditingName ? nameDraft : displayName}
             readOnly={!isEditingName}
-            title={isEditingName ? undefined : '点击修改显示名称'}
+            autoFocus={isEditingName}
+            variant={isEditingName ? 'outline' : 'flushed'}
             onClick={(e) => {
                 e.stopPropagation();
-                if (!isEditingName) startEditName(e);
+                if (!isEditingName) {
+                    setNameDraft(displayName);
+                    setIsEditingName(true);
+                }
             }}
             onChange={(e) => {
                 if (!isEditingName) return;
@@ -793,47 +817,24 @@ function AccountInfo({
                 commitDisplayName();
             }}
             onKeyDown={(e) => {
-                if (!isEditingName) return;
-                if (composingRef.current) return;
-                if (e.key === 'Enter') {
-                    e.preventDefault();
-                    (e.target as HTMLInputElement).blur();
-                }
+                if (!isEditingName || composingRef.current) return;
+                if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
                 if (e.key === 'Escape') {
-                    e.preventDefault();
                     setNameDraft(displayName);
                     setIsEditingName(false);
                 }
             }}
             fontWeight="bold"
-            fontSize="inherit"
-            lineHeight="1.25"
-            h="2rem"
-            minH="2rem"
-            minW="4.5em"
-            w="auto"
-            maxW="14em"
-            px={2}
-            py={0}
-            borderRadius="md"
-            borderWidth="1px"
-            borderColor={isEditingName ? 'blue.focusRing' : 'transparent'}
-            bg={isEditingName ? 'bg.panel' : 'transparent'}
-            boxShadow="none"
-            cursor={isEditingName ? 'text' : 'text'}
-            _hover={
-                isEditingName
-                    ? undefined
-                    : { bg: 'bg.subtle', borderColor: 'border.subtle' }
-            }
-            _focusVisible={{
-                borderColor: 'blue.focusRing',
-                boxShadow: 'none',
-            }}
-            css={{
-                // 取消部分浏览器只读态发灰
-                '&:read-only': { opacity: 1, cursor: 'text' },
-            }}
+            maxW="8em"
+            minW="4em"
+            h="2em"
+            px={isEditingName ? 2 : 0}
+            lineHeight="1"
+            cursor="text"
+            title={isEditingName ? undefined : '点击修改显示名称'}
+            _hover={!isEditingName ? { color: 'blue.fg' } : undefined}
+            borderColor={isEditingName ? undefined : 'transparent'}
+            boxShadow={isEditingName ? undefined : 'none'}
         />
     );
 
@@ -969,7 +970,11 @@ function AccountInfo({
         }
     };
 
-    const renderActionButtons = (size: 'xs' | 'sm' | 'md' = 'xs', flexMode = false) => (
+    // 函数渲染，不要内嵌组件（否则每帧新类型，按钮整卸整挂）
+    const renderActionButtons = (
+        size: 'xs' | 'sm' | 'md' = 'xs',
+        flexMode = false,
+    ) => (
         <HStack
             gap={flexMode ? 0 : 1}
             w={flexMode ? 'full' : undefined}
@@ -1043,16 +1048,23 @@ function AccountInfo({
         </HStack>
     );
 
-
     if (isTableView) {
         return (
             <Table.Row key={alias} bg="bg.panel" _hover={{ bg: 'bg.muted' }}>
-                <Table.Cell px={3} py={3} width="50px" onClick={(e) => e.stopPropagation()}>
-                    <Flex align="center" minH="2.5em">
+                <Table.Cell px={2} py={3} width="56px" onClick={(e) => e.stopPropagation()}>
+                    <Flex align="center" justify="center" minH="2.75em" px={1} py={1}>
                         <Checkbox
                             checked={isSelected}
                             onCheckedChange={onToggleSelect}
                             colorPalette="blue"
+                            size="md"
+                            css={{
+                                '& [data-part=control], & .chakra-checkbox__control': {
+                                    borderRadius: '9999px',
+                                    width: '1.25rem',
+                                    height: '1.25rem',
+                                },
+                            }}
                         />
                     </Flex>
                 </Table.Cell>
@@ -1067,7 +1079,6 @@ function AccountInfo({
                         onClick={goDetail}
                         title="进入详细设置"
                     >
-                        {/* ✅ 补回内层 Flex 容器 */}
                         <Flex align="center" gap={1} minW={0} flex="1" lineHeight="1">
                             <Flex
                                 boxSize="2em"
@@ -1087,10 +1098,11 @@ function AccountInfo({
                                 onClick={(e) => e.stopPropagation()}
                                 display="flex"
                                 alignItems="center"
-                                h="2rem"
+                                lineHeight="1"
                                 fontSize="sm"
-                                flex="0 1 auto"
+                                flexShrink={1}
                                 minW={0}
+                                maxW={displayName !== alias ? '42%' : '70%'}
                             >
                                 {nameInput}
                             </Box>
@@ -1100,22 +1112,30 @@ function AccountInfo({
                                     as="span"
                                     fontSize="xs"
                                     color="fg.muted"
-                                                    whiteSpace="nowrap"
-                    lineHeight="1"
+                                    whiteSpace="nowrap"
+                                    lineHeight="1"
+                                    flex="1 1 4.5em"
+                                    minW="4.5em"
+                                    overflow="hidden"
+                                    textOverflow="ellipsis"
+                                    title={alias}
                                 >
                                     {alias}
                                 </Text>
                             )}
-                            {defaultAccount === account.name && (
-                                <Tag.Root size="sm" colorPalette="purple" variant="solid" flexShrink={0}>
-                                    <Tag.Label>默认</Tag.Label>
-                                </Tag.Root>
-                            )}
-                            {account.clan_forbid && (
-                                <Tag.Root size="sm" colorPalette="red" variant="solid" flexShrink={0}>
-                                    <Tag.Label>公会战禁用</Tag.Label>
-                                </Tag.Root>
-                            )}
+
+                            <Flex align="center" gap={1} flexShrink={0}>
+                                {defaultAccount === account.name && (
+                                    <Tag.Root size="sm" p={0.5} colorPalette="purple" variant="solid" flexShrink={0}>
+                                        <Tag.Label fontSize="2xs" lineHeight="1">默认</Tag.Label>
+                                    </Tag.Root>
+                                )}
+                                {account.clan_forbid && (
+                                    <Tag.Root size="sm" colorPalette="red" variant="solid" flexShrink={0}>
+                                        <Tag.Label fontSize="2xs" lineHeight="1">公会战禁用</Tag.Label>
+                                    </Tag.Root>
+                                )}
+                            </Flex>
                         </Flex>
 
                         <Box flexShrink={0} onClick={(e) => e.stopPropagation()}>
@@ -1124,7 +1144,7 @@ function AccountInfo({
                                 isOpen={deleteConfirm.open}
                                 onClose={deleteConfirm.onClose}
                                 title="删除账号"
-                                body={`确定删除账号${alias}吗？`}
+                                body={`确定删除账号${displayName || alias}吗？`}
                                 onConfirm={handleDeleteAccount}
                             >
                                 {' '}
@@ -1135,13 +1155,17 @@ function AccountInfo({
                                 variant="ghost"
                                 colorPalette="gray"
                                 title="删除账号"
+                                minW="1.5rem"
+                                h="1.5rem"
+                                p={0}
+                                fontSize="1.25rem"
                                 onClick={(e) => {
                                     e.stopPropagation();
                                     deleteConfirm.onOpen();
                                 }}
                                 _hover={{ bg: 'red.subtle', color: 'red.fg' }}
                             >
-                                <FiX />
+                                <FiX size={18} strokeWidth={2.5} />
                             </IconButton>
                         </Box>
                     </Flex>
@@ -1185,36 +1209,57 @@ function AccountInfo({
             shadow="sm"
             borderRadius="2xl"
             borderWidth="1px"
-            borderColor="border.subtle"
+            borderColor={isSelected ? 'blue.focusRing' : 'border.subtle'}
             transition="all 0.2s"
+            overflow="hidden"
+            cursor="pointer"
+            onClick={goDetail}
+            /* 不要在 Root 上挂 title：会继承到选框/删除/状态，悬停误提示「进入详细设置」 */
             _hover={{ shadow: 'lg', transform: 'translateY(-2px)', borderColor: 'blue.focusRing' }}
         >
-            <Box
-                cursor="pointer"
-                onClick={goDetail}
-                title="进入详细设置"
-            >
-                <Card.Header pb={2}>
-                    <Flex justify="space-between" align="start" gap={2}>
-                        <Flex align="center" gap={0} minW={0} flex="1" pt={0}>
+            <Card.Header px={4} pt={4} pb={3}>
+                <Flex justify="space-between" align="center" gap={1} minH="2.75em">
+                    <Flex align="center" gap={0} minW={0} flex="1">
+                        <Box
+                            onClick={(e) => e.stopPropagation()}
+                            flexShrink={0}
+                            display="flex"
+                            alignItems="center"
+                            justifyContent="center"
+                            pl={0.5}
+                            pr={1}
+                            py={1}
+                            minW="2rem"
+                            minH="2rem"
+                            title="选择账号"
+                            cursor="default"
+                        >
+                            <Checkbox
+                                checked={isSelected}
+                                onCheckedChange={onToggleSelect}
+                                colorPalette="blue"
+                                size="md"
+                                css={{
+                                    '& [data-part=control], & .chakra-checkbox__control': {
+                                        borderRadius: '9999px',
+                                        width: '1.25rem',
+                                        height: '1.25rem',
+                                    },
+                                }}
+                            />
+                        </Box>
+
+                        <Flex align="center" gap={2} minW={0} flex="1" h="full" minH="2.75em">
                             <Box
                                 onClick={(e) => e.stopPropagation()}
-                                flexShrink={0}
                                 display="flex"
                                 alignItems="center"
                                 lineHeight="1"
-                            >
-                                <Radio value={alias} colorPalette="purple" />
-                            </Box>
-                            <Box
-                                maxW="70%"
-                                minW={0}
-                                onClick={(e) => e.stopPropagation()}
-                                display="flex"
-                                alignItems="center"
-                                h="2rem"
                                 fontSize="lg"
-                                flex="0 1 auto"
+                                minW={0}
+                                flexShrink={1}
+                                maxW={displayName !== alias ? '48%' : '70%'}
+                                title=""
                             >
                                 {nameInput}
                             </Box>
@@ -1226,73 +1271,112 @@ function AccountInfo({
                                     whiteSpace="nowrap"
                                     overflow="hidden"
                                     textOverflow="ellipsis"
-                                    maxW="30%"
+                                    flex="1 1 4.5em"
+                                    minW="1.5em"
+                                    maxW="35%"
                                     lineHeight="1"
                                     title={alias}
                                 >
                                     {alias}
                                 </Text>
                             )}
-                            {account.clan_forbid && (
-                                <Tag.Root size="sm" colorPalette="red" variant="subtle" flexShrink={0}>
-                                    <Tag.Label>禁用</Tag.Label>
-                                </Tag.Root>
-                            )}
+                            <Flex align="center" gap={1} flexShrink={0}>
+                                {defaultAccount === account.name && (
+                                    <Tag.Root size="sm" p={0.5} colorPalette="purple" variant="solid" flexShrink={0}>
+                                        <Tag.Label fontSize="2xs" lineHeight="1">默认</Tag.Label>
+                                    </Tag.Root>
+                                )}
+                                {account.clan_forbid && (
+                                    <Tag.Root size="sm" p={0.5} colorPalette="red" variant="subtle" flexShrink={0}>
+                                        <Tag.Label fontSize="2xs" lineHeight="1">禁用</Tag.Label>
+                                    </Tag.Root>
+                                )}
+                            </Flex>
+                            {/* 空白热区：真正吃到 native title */}
+                            <Box
+                                flex="1"
+                                alignSelf="stretch"
+                                minW="12px"
+                                minH="100%"
+                                title="进入详细设置"
+                                cursor="pointer"
+                                aria-label="进入详细设置"
+                            />
                         </Flex>
-
-                        <Box onClick={(e) => e.stopPropagation()} flexShrink={0}>
-                            <Alert
-                                leastDestructiveRef={cancelRef}
-                                isOpen={deleteConfirm.open}
-                                onClose={deleteConfirm.onClose}
-                                title="删除账号"
-                                body={`确定删除账号${alias}吗？`}
-                                onConfirm={handleDeleteAccount}
-                            >
-                                {' '}
-                            </Alert>
-                            <IconButton
-                                size="xs"
-                                variant="ghost"
-                                colorPalette="gray"
-                                aria-label="Delete"
-                                title="删除账号"
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    deleteConfirm.onOpen();
-                                }}
-                                _hover={{ bg: 'red.subtle', color: 'red.fg' }}
-                            >
-                                <FiX />
-                            </IconButton>
-                        </Box>
                     </Flex>
-                </Card.Header>
 
-                <Card.Body py={2}>
-                    <Box bg="bg.subtle" p={2} borderRadius="lg">
-                        <Flex justify="space-between" align="center" mb={1} gap={2}>
-                            <Text fontSize="xs" color="fg.muted">
-                                上次运行
-                            </Text>
-                            <Text fontSize="xs" fontWeight="bold">
-                                {cleanTime || '—'}
-                            </Text>
-                        </Flex>
-                        <Flex justify="space-between" align="center" gap={2}>
-                            <Text fontSize="xs" color="fg.muted" flexShrink={0}>
-                                状态
-                            </Text>
-                            <Tag.Root size="sm" colorPalette={statusMeta.color} flexShrink={0}>
-                                <Tag.StartElement>{statusMeta.icon}</Tag.StartElement>
-                                <Tag.Label>{cleanStatus}</Tag.Label>
-                            </Tag.Root>
-                        </Flex>
+                    <Box
+                        onClick={(e) => e.stopPropagation()}
+                        flexShrink={0}
+                        pr={0.5}
+                        title="删除账号"
+                        cursor="default"
+                        display="flex"
+                        alignItems="center"
+                    >
+                        <Alert
+                            leastDestructiveRef={cancelRef}
+                            isOpen={deleteConfirm.open}
+                            onClose={deleteConfirm.onClose}
+                            title="删除账号"
+                            body={`确定删除账号${displayName || alias}吗？`}
+                            onConfirm={handleDeleteAccount}
+                        >
+                            {' '}
+                        </Alert>
+                        <IconButton
+                            size="xs"
+                            variant="ghost"
+                            colorPalette="gray"
+                            aria-label="Delete"
+                            title="删除账号"
+                            minW="1.5rem"
+                            h="1.6rem"
+                            p={0}
+                            fontSize="1.35rem"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                deleteConfirm.onOpen();
+                            }}
+                            _hover={{ bg: 'red.subtle', color: 'red.fg' }}
+                        >
+                            <FiX size={20} strokeWidth={2.5} />
+                        </IconButton>
                     </Box>
-                </Card.Body>
-            </Box>
+                </Flex>
+            </Card.Header>
 
-            <Card.Footer pt={2}>
+            {/* 仅灰底窗体本身不进详情；Body 上下/左右一丝空白仍进详情 */}
+            <Card.Body px={4} py={2} title="进入详细设置" cursor="pointer">
+                <Box
+                    bg="bg.subtle"
+                    p={2}
+                    borderRadius="lg"
+                    cursor="default"
+                    title=""
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <Flex justify="space-between" align="center" mb={1} gap={2}>
+                        <Text fontSize="xs" color="fg.muted">
+                            上次运行
+                        </Text>
+                        <Text fontSize="xs" fontWeight="bold">
+                            {cleanTime || '—'}
+                        </Text>
+                    </Flex>
+                    <Flex justify="space-between" align="center" gap={2}>
+                        <Text fontSize="xs" color="fg.muted" flexShrink={0}>
+                            状态
+                        </Text>
+                        <Tag.Root size="sm" colorPalette={statusMeta.color} flexShrink={0}>
+                            <Tag.StartElement>{statusMeta.icon}</Tag.StartElement>
+                            <Tag.Label>{cleanStatus}</Tag.Label>
+                        </Tag.Root>
+                    </Flex>
+                </Box>
+            </Card.Body>
+
+            <Card.Footer px={4} pt={2} pb={3} title="进入详细设置">
                 {renderActionButtons('md', true)}
             </Card.Footer>
         </Card.Root>

--- a/src/components/Account/DashBoard.tsx
+++ b/src/components/Account/DashBoard.tsx
@@ -38,6 +38,27 @@ import { useDisclosure } from '@chakra-ui/react';
 import ConfigSyncModal from './ConfigSyncModal';
 import type { Candidate, ConfigType, ConfigValue, ModuleResponse } from '@interfaces/Module';
 
+async function getErrorDescription(err: unknown, fallback = '网络错误'): Promise<string> {
+    const data = (err as { response?: { data?: unknown } })?.response?.data;
+    try {
+        if (data == null) {
+            if (err instanceof Error && err.message) return err.message;
+            return fallback;
+        }
+        if (typeof Blob !== 'undefined' && data instanceof Blob) {
+            const t = await data.text();
+            return t || fallback;
+        }
+        if (typeof data === 'string') return data || fallback;
+        if (typeof data === 'object') {
+            try { return JSON.stringify(data); } catch { return fallback; }
+        }
+        return String(data);
+    } catch {
+        return fallback;
+    }
+}
+
 const handle: Map<string, (arg0: boolean) => void> = new Map<string, (arg0: boolean) => void>();
 
 const DISPLAY_NAME_KEY = (alias: string) => `autopcr_displayName_${alias}`;
@@ -209,41 +230,43 @@ export function DashBoard() {
     };
 
     const handleCreateAccount = () => {
-        if (creatAccountSwitch.open) {
-            if (!alias || alias.trim() === '') {
+        if (!creatAccountSwitch.open) {
+            creatAccountSwitch.onOpen();
+            return;
+        }
+        if (!alias || alias.trim() === '') {
+            toaster.create({
+                type: 'warning',
+                title: '需输入名字，此次未创建',
+            });
+            creatAccountSwitch.onClose();
+            setAlias('');
+            return;
+        }
+
+        postAccount(alias)
+            .then((res) => {
+                toaster.create({
+                    type: 'success',
+                    title: '创建账号成功',
+                    description: res,
+                });
+                creatAccountSwitch.onClose();
+                setAlias('');
+                freshAccountInfo.onToggle();
+            })
+            .catch(async (err: AxiosError) => {
                 toaster.create({
                     type: 'error',
                     title: '创建账号失败',
-                    description: '账号昵称不能为空',
+                    description: await getErrorDescription(err),
                 });
-                return;
-            }
-
-            postAccount(alias)
-                .then((res) => {
-                    toaster.create({
-                        type: 'success',
-                        title: '创建账号成功',
-                        description: res,
-                    });
-                    creatAccountSwitch.onToggle();
-                    setAlias('');
-                    freshAccountInfo.onToggle();
-                })
-                .catch((err: AxiosError) => {
-                    toaster.create({
-                        type: 'error',
-                        title: '创建账号失败',
-                        description: (err?.response?.data as string) || '网络错误',
-                    });
-                });
-        } else {
-            creatAccountSwitch.onToggle();
-        }
+            });
     };
 
     const handleAccountImport = (event: ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
+        event.target.value = '';
         if (file) {
             postAccountImport(file)
                 .then((res) => {
@@ -480,9 +503,7 @@ export function DashBoard() {
                                     variant={creatAccountSwitch.open ? "solid" : "solid"}
                                     colorPalette={creatAccountSwitch.open ? "red" : "green"}
                                     onClick={() => {
-                                        if(creatAccountSwitch.open && !alias) creatAccountSwitch.onToggle();
-                                        else if (creatAccountSwitch.open && alias) handleCreateAccount();
-                                        else creatAccountSwitch.onToggle();
+                                        handleCreateAccount();
                                     }}
                                 >
                                     {creatAccountSwitch.open ? <FiCheck /> : <FiUserPlus />}
@@ -526,7 +547,7 @@ export function DashBoard() {
                     <Table.Root variant="outline" colorPalette="blue" size="sm" bg="bg.panel" borderRadius="xl" boxShadow="sm" ml="0" mr="auto">
                         <Table.Header position="sticky" top={0} bg="bg.subtle" zIndex={1} boxShadow="sm">
                             <Table.Row>
-                                <Table.ColumnHeader px={5} fontSize="md" py={4} fontWeight="bold" width="0%">
+                                <Table.ColumnHeader px={0} fontSize="md" py={4} fontWeight="bold" width="5%" textAlign="center">
                                     <Checkbox
                                         checked={
                                             (selectedAccounts.length > 0 && selectedAccounts.length < (userInfo?.accounts?.length ?? 0))
@@ -665,6 +686,7 @@ function AccountInfo({
     const [displayName, setDisplayName] = useState(() => getDisplayName(alias));
     const [nameDraft, setNameDraft] = useState(displayName);
     const composingRef = useRef(false);
+    const nameInputRef = useRef<HTMLInputElement>(null);
 
     const clean = account.daily_clean_time;
     const cleanStatus = clean?.status || '未知';
@@ -740,7 +762,7 @@ function AccountInfo({
     };
 
     const handleDailyResult = () => {
-        toaster.create({ type: 'info', title: `正在获取${displayName || alias}的日常结果...` });
+        toaster.create({ type: 'info', title: `正在获取${alias}的日常结果...` });
         getAccountDailyResultList(alias)
             .then(async (res) => {
                 toaster.create({ type: 'success', title: '获取日常结果成功' });
@@ -750,7 +772,7 @@ function AccountInfo({
                 toaster.create({
                     type: 'error',
                     title: '获取日常结果失败',
-                    description: (await (err?.response?.data as Blob).text()) || '网络错误',
+                    description: await getErrorDescription(err),
                 });
             });
     };
@@ -758,6 +780,15 @@ function AccountInfo({
     const goDetail = () => {
         void navigate({ to: `${DashBoardRoute.to || ''}${alias}` as any });
     };
+
+
+    useEffect(() => {
+        if (isEditingName) {
+            // autoFocus 只在挂载时生效；编辑态切换时手动 focus
+            const t = window.setTimeout(() => nameInputRef.current?.focus(), 0);
+            return () => window.clearTimeout(t);
+        }
+    }, [isEditingName]);
 
     const commitDisplayName = () => {
         const next = nameDraft.trim();
@@ -788,10 +819,10 @@ function AccountInfo({
     // 始终同一 Input：可编辑区域与名字位置重合
     const nameInput = (
         <Input
+            ref={nameInputRef}
             size="sm"
             value={isEditingName ? nameDraft : displayName}
             readOnly={!isEditingName}
-            autoFocus={isEditingName}
             variant={isEditingName ? 'outline' : 'flushed'}
             onClick={(e) => {
                 e.stopPropagation();
@@ -810,10 +841,25 @@ function AccountInfo({
             onCompositionEnd={(e) => {
                 composingRef.current = false;
                 setNameDraft((e.target as HTMLInputElement).value);
+                // 组词中途点到别处：compositionend 时可能已失焦，补一次提交，避免卡在编辑态
+                const el = e.target as HTMLInputElement;
+                window.setTimeout(() => {
+                    if (document.activeElement !== el) {
+                        commitDisplayName();
+                    }
+                }, 0);
             }}
             onBlur={() => {
                 if (!isEditingName) return;
-                if (composingRef.current) return;
+                if (composingRef.current) {
+                    // 组词中 blur：等 composition 结束后由上面的 timeout 处理；再兜底一次
+                    window.setTimeout(() => {
+                        if (!composingRef.current) {
+                            commitDisplayName();
+                        }
+                    }, 0);
+                    return;
+                }
                 commitDisplayName();
             }}
             onKeyDown={(e) => {
@@ -825,7 +871,7 @@ function AccountInfo({
                 }
             }}
             fontWeight="bold"
-            maxW="8em"
+            maxW="12em"
             minW="4em"
             h="2em"
             px={isEditingName ? 2 : 0}
@@ -1079,6 +1125,7 @@ function AccountInfo({
                         onClick={goDetail}
                         title="进入详细设置"
                     >
+                        {/* ✅ 补回内层 Flex 容器；曾用名 minW 保底，标签不挤占省略空间 */}
                         <Flex align="center" gap={1} minW={0} flex="1" lineHeight="1">
                             <Flex
                                 boxSize="2em"
@@ -1124,6 +1171,7 @@ function AccountInfo({
                                 </Text>
                             )}
 
+                            {/* 标签单独一组 flexShrink=0，避免反噬曾用名 */}
                             <Flex align="center" gap={1} flexShrink={0}>
                                 {defaultAccount === account.name && (
                                     <Tag.Root size="sm" p={0.5} colorPalette="purple" variant="solid" flexShrink={0}>
@@ -1144,11 +1192,12 @@ function AccountInfo({
                                 isOpen={deleteConfirm.open}
                                 onClose={deleteConfirm.onClose}
                                 title="删除账号"
-                                body={`确定删除账号${displayName || alias}吗？`}
+                                body={`确定删除账号${alias}吗？`}
                                 onConfirm={handleDeleteAccount}
                             >
                                 {' '}
                             </Alert>
+                            {/* 热区略小、叉图形略大 */}
                             <IconButton
                                 aria-label="Delete"
                                 size="xs"
@@ -1171,6 +1220,7 @@ function AccountInfo({
                     </Flex>
                 </Table.Cell>
 
+                {/* 表格状态列：保持可进详情（仅卡片状态区做安全点击区） */}
                 <Table.Cell
                     px={3}
                     py={3}
@@ -1217,102 +1267,88 @@ function AccountInfo({
             /* 不要在 Root 上挂 title：会继承到选框/删除/状态，悬停误提示「进入详细设置」 */
             _hover={{ shadow: 'lg', transform: 'translateY(-2px)', borderColor: 'blue.focusRing' }}
         >
-            <Card.Header px={4} pt={4} pb={3}>
-                <Flex justify="space-between" align="center" gap={1} minH="2.75em">
-                    <Flex align="center" gap={0} minW={0} flex="1">
+            {/* 整卡 onClick 进详情；Header/状态/按钮区内控件自行 stopPropagation */}
+            <Card.Header px={4} pt={3} pb={3} minH="2.75em" title="进入详细设置">
+                {/* 整 Header 随卡片进详情；仅选框/改名/删除 stopPropagation */}
+                <Flex align="center" gap={2} minH="2.25em">
+                    <Box
+                        onClick={(e) => e.stopPropagation()}
+                        flexShrink={0}
+                        display="flex"
+                        alignItems="center"
+                        justifyContent="center"
+                        title="选择账号"
+                        cursor="default"
+                    >
+                        <Checkbox
+                            checked={isSelected}
+                            onCheckedChange={onToggleSelect}
+                            colorPalette="blue"
+                            size="md"
+                            css={{
+                                '& [data-part=control], & .chakra-checkbox__control': {
+                                    borderRadius: '9999px',
+                                    width: '1.25rem',
+                                    height: '1.25rem',
+                                },
+                            }}
+                        />
+                    </Box>
+
+                    <Flex align="center" gap={2} minW={0} flex="1" overflow="hidden">
                         <Box
                             onClick={(e) => e.stopPropagation()}
-                            flexShrink={0}
                             display="flex"
                             alignItems="center"
-                            justifyContent="center"
-                            pl={0.5}
-                            pr={1}
-                            py={1}
-                            minW="2rem"
-                            minH="2rem"
-                            title="选择账号"
+                            lineHeight="1"
+                            fontSize="lg"
+                            flex="1 1 6em"
+                            minW="4em"
+                            maxW={displayName !== alias ? '52%' : '75%'}
+                            overflow="hidden"
+                            title=""
                             cursor="default"
                         >
-                            <Checkbox
-                                checked={isSelected}
-                                onCheckedChange={onToggleSelect}
-                                colorPalette="blue"
-                                size="md"
-                                css={{
-                                    '& [data-part=control], & .chakra-checkbox__control': {
-                                        borderRadius: '9999px',
-                                        width: '1.25rem',
-                                        height: '1.25rem',
-                                    },
-                                }}
-                            />
+                            {nameInput}
                         </Box>
 
-                        <Flex align="center" gap={2} minW={0} flex="1" h="full" minH="2.75em">
-                            <Box
-                                onClick={(e) => e.stopPropagation()}
-                                display="flex"
-                                alignItems="center"
+                        {displayName !== alias && (
+                            <Text
+                                as="span"
+                                fontSize="xs"
+                                color="fg.muted"
+                                whiteSpace="nowrap"
+                                overflow="hidden"
+                                textOverflow="ellipsis"
+                                flex="1 1 4em"
+                                minW="3em"
+                                maxW="32%"
                                 lineHeight="1"
-                                fontSize="lg"
-                                minW={0}
-                                flexShrink={1}
-                                maxW={displayName !== alias ? '48%' : '70%'}
-                                title=""
+                                title={alias}
                             >
-                                {nameInput}
-                            </Box>
-                            {displayName !== alias && (
-                                <Text
-                                    as="span"
-                                    fontSize="xs"
-                                    color="fg.muted"
-                                    whiteSpace="nowrap"
-                                    overflow="hidden"
-                                    textOverflow="ellipsis"
-                                    flex="1 1 4.5em"
-                                    minW="1.5em"
-                                    maxW="35%"
-                                    lineHeight="1"
-                                    title={alias}
-                                >
-                                    {alias}
-                                </Text>
+                                {alias}
+                            </Text>
+                        )}
+
+                        <Flex align="center" gap={1} flexShrink={0} minW={0}>
+                            {defaultAccount === account.name && (
+                                <Tag.Root size="sm" p={0.5} colorPalette="purple" variant="solid" flexShrink={0}>
+                                    <Tag.Label fontSize="2xs" lineHeight="1" whiteSpace="nowrap">默认</Tag.Label>
+                                </Tag.Root>
                             )}
-                            <Flex align="center" gap={1} flexShrink={0}>
-                                {defaultAccount === account.name && (
-                                    <Tag.Root size="sm" p={0.5} colorPalette="purple" variant="solid" flexShrink={0}>
-                                        <Tag.Label fontSize="2xs" lineHeight="1">默认</Tag.Label>
-                                    </Tag.Root>
-                                )}
-                                {account.clan_forbid && (
-                                    <Tag.Root size="sm" p={0.5} colorPalette="red" variant="subtle" flexShrink={0}>
-                                        <Tag.Label fontSize="2xs" lineHeight="1">禁用</Tag.Label>
-                                    </Tag.Root>
-                                )}
-                            </Flex>
-                            {/* 空白热区：真正吃到 native title */}
-                            <Box
-                                flex="1"
-                                alignSelf="stretch"
-                                minW="12px"
-                                minH="100%"
-                                title="进入详细设置"
-                                cursor="pointer"
-                                aria-label="进入详细设置"
-                            />
+                            {account.clan_forbid && (
+                                <Tag.Root size="sm" p={0.5} colorPalette="red" variant="subtle" flexShrink={0}>
+                                    <Tag.Label fontSize="2xs" lineHeight="1" whiteSpace="nowrap">禁用</Tag.Label>
+                                </Tag.Root>
+                            )}
                         </Flex>
                     </Flex>
 
                     <Box
                         onClick={(e) => e.stopPropagation()}
                         flexShrink={0}
-                        pr={0.5}
                         title="删除账号"
                         cursor="default"
-                        display="flex"
-                        alignItems="center"
                     >
                         <Alert
                             leastDestructiveRef={cancelRef}
@@ -1331,16 +1367,23 @@ function AccountInfo({
                             aria-label="Delete"
                             title="删除账号"
                             minW="1.5rem"
-                            h="1.6rem"
+                            w="1.5rem"
+                            h="1.5rem"
                             p={0}
-                            fontSize="1.35rem"
                             onClick={(e) => {
                                 e.stopPropagation();
                                 deleteConfirm.onOpen();
                             }}
                             _hover={{ bg: 'red.subtle', color: 'red.fg' }}
+                            css={{
+                                '& svg': {
+                                    width: '1.4em',
+                                    height: '1.4em',
+                                    strokeWidth: 2.5,
+                                },
+                            }}
                         >
-                            <FiX size={20} strokeWidth={2.5} />
+                            <FiX />
                         </IconButton>
                     </Box>
                 </Flex>

--- a/src/components/Account/Module.tsx
+++ b/src/components/Account/Module.tsx
@@ -1,12 +1,12 @@
-import { Box, Button, Card, Collapsible, Flex, HStack, Heading, Separator, Stack, Tag, useDisclosure } from '@chakra-ui/react'
+import { Box, Button, Card, Flex, HStack, Heading, Separator, Stack, Tag, useDisclosure } from '@chakra-ui/react'
 import { ConfigValue, ModuleInfo } from '@interfaces/Module';
 import { FiChevronDown, FiCopy, FiStar } from 'react-icons/fi';
 import { getAccountAreaSingleResultList, postAccountAreaSingle, putAccountConfig, getAccountConfig, putAccountConfigs } from '@api/Account';
-import * as React from 'react';
+
 import Alert from '../alert';
 import { AxiosError } from 'axios';
 import { Checkbox } from '../../components/ui/checkbox';
-import Config from './Config';
+import Config, { enqueueConfigSave } from './Config';
 import NiceModal from '@ebay/nice-modal-react';
 import ResultInfoModal from './ResultInfoModal';
 import ModuleSyncModal from './ModuleSyncModal';
@@ -33,27 +33,26 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
         e.stopPropagation();
         const favKey = `autopcr_fav_${alias}`;
         const stored = localStorage.getItem(favKey);
-         let favMap: Record<string, string[]> = {};
-         if (stored) {
-             try {
-                 favMap = JSON.parse(stored) as Record<string, string[]>;
-             } catch {
-                 favMap = {};
-             }
-         }
+        let favMap: Record<string, string[]> = {};
+        if (stored) {
+            try {
+                favMap = JSON.parse(stored) as Record<string, string[]>;
+            } catch {
+                favMap = {};
+            }
+        }
         const areaFavs = new Set(favMap[areaKey] || []);
-        
+
         const isNowFav = !areaFavs.has(info.key);
         if (isNowFav) {
             areaFavs.add(info.key);
         } else {
             areaFavs.delete(info.key);
         }
-        
+
         favMap[areaKey] = Array.from(areaFavs);
         localStorage.setItem(favKey, JSON.stringify(favMap));
-        
-        // 同步通知父组件更新本地状态，使星星立即变色
+
         onConfigUpdate?.(`_fav_${info.key}`, isNowFav);
     };
 
@@ -61,17 +60,14 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
         const isChecked = !!details.checked;
         const previousValue = config[info.key];
 
-        // 1. 乐观更新：0ms 立即在界面打勾/取消打勾
         onConfigUpdate?.(info.key, isChecked);
 
-        // 2. 异步请求后端，失败时回滚
-        putAccountConfig(alias, info?.key, isChecked).then((response) => {
+        enqueueConfigSave(alias, () => putAccountConfig(alias, info?.key, isChecked)).then((response) => {
             toaster.create({ type: 'success', title: '保存成功', description: response });
         }).catch((err: AxiosError) => {
-            // 请求失败：回滚勾选状态
             onConfigUpdate?.(info.key, previousValue);
-            toaster.create({ type: 'error', title: '保存失败', description: err.response?.data as string || "网络错误" });
-        })
+            toaster.create({ type: 'error', title: '保存失败', description: (err.response?.data as string) || '网络错误' });
+        });
     };
 
     const handleExecute = () => {
@@ -173,23 +169,32 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
     }
 
     return (
-        <Card.Root 
-            colorPalette="brand" 
-            bg="bg.panel" 
-            borderRadius="2xl" 
-            shadow="sm" 
+        <Card.Root
+            colorPalette="brand"
+            bg="bg.panel"
+            borderRadius="2xl"
+            shadow="sm"
             borderWidth="1px"
             borderColor="border.subtle"
             transition="all 0.2s"
             _hover={{ shadow: 'md', borderColor: "blue.400" }}
-            {...rest} 
+            {...rest}
         >
-            <Card.Header py={3} cursor="pointer" onClick={onToggleExpand}>
+            <Card.Header
+                py={3}
+                cursor="pointer"
+                onClick={() => {
+                    // 折叠/展开前先让当前输入失焦，触发 Config 的 onBlur 保存，避免草稿被卸载丢掉
+                    const ae = document.activeElement as HTMLElement | null;
+                    if (ae && typeof ae.blur === 'function') ae.blur();
+                    // 等 blur 的同步 onChange/onBlur 入队后再切展开态
+                    window.setTimeout(() => onToggleExpand(), 0);
+                }}
+            >
                 <Flex align="center" wrap="wrap" gap={2}>
                     <Box onClick={(e) => e.stopPropagation()} mr={{ base: 1, md: 1 }}>
-                         {/* 受控组件绑定，保证导入/更新后界面同步勾选 */}
-                         <Checkbox 
-                            checked={!!config[info.key]} 
+                        <Checkbox
+                            checked={!!config[info.key]}
                             onCheckedChange={onCheckedChange}
                             size="lg"
                             colorPalette="blue"
@@ -197,10 +202,8 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
                     </Box>
                     <Box flex="1" minW="0">
                         <HStack gap={2} flexWrap="wrap" align="center">
-                            {/* 模块名称 */}
                             <Heading size={{ base: 'sm', md: 'md' }} fontWeight="bold" truncate>{info?.name}</Heading>
-                            
-                            {/* 收藏黄星 */}
+
                             <Box
                                 onClick={handleToggleFav}
                                 cursor="pointer"
@@ -213,8 +216,7 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
                             >
                                 <FiStar fill={config?.[`_fav_${info.key}`] ? "currentColor" : "none"} />
                             </Box>
-                            
-                            {/* 标签 */}
+
                             {info?.tags.map(item => (
                                 <Tag.Root key={item} colorPalette="purple" variant="subtle" size="sm">
                                     <Tag.Label>{item}</Tag.Label>
@@ -232,39 +234,39 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
                         {areaKey === 'daily' && (
                             <Button size={{ base: 'xs', md: 'sm' }} variant="ghost" colorPalette='teal' loading={isOpen} onClick={handleSyncConfig} aria-label="同步配置"><FiCopy /></Button>
                         )}
-                         <Box color="fg.muted" transition="transform 0.2s" transform={isExpanded ? "rotate(180deg)" : "rotate(0deg)"}>
-                             <FiChevronDown />
-                         </Box>
+                        <Box color="fg.muted" transition="transform 0.2s" transform={isExpanded ? "rotate(180deg)" : "rotate(0deg)"}>
+                            <FiChevronDown />
+                        </Box>
                     </HStack>
                 </Flex>
             </Card.Header>
 
-            <Collapsible.Root open={isExpanded}>
-                <Collapsible.Content>
-                    <Card.Body pt={0} animation="fade-in 0.2s">
-                        <Stack gap='4'>
-                            {info?.description &&
-                                <Box bg="bg.subtle" p={3} borderRadius="lg" fontSize="sm" color="fg.muted">
-                                    {info?.description}
-                                </Box>
-                            }
-                            {info?.description && info?.config_order.length != 0 && <Separator borderColor="border.subtle" />}
-                            {info?.config_order.length != 0 &&
-                                <Box>
-                                    <Stack gap='4'>
-                                        <Heading size='sm' color="fg.subtle">设置项</Heading>
-                                        {
-                                            info?.config_order.map((key) => (
-                                                <Config key={key} alias={alias} value={config[key]} info={info.config[key]} />
-                                            ))
-                                        }
-                                    </Stack>
-                                </Box>
-                            }
-                        </Stack>
-                    </Card.Body>
-                </Collapsible.Content>
-            </Collapsible.Root>
+            {/* 折叠时不挂 Config：条件渲染，兼容各版 Chakra */}
+            {isExpanded && (
+                <Card.Body pt={0} animation="fade-in 0.2s">
+                    <Stack gap='1.5'>
+                        {info?.description &&
+                            <Box bg="bg.subtle" px={3} py={2} borderRadius="lg" fontSize="sm" color="fg.muted">
+                                {info?.description}
+                            </Box>
+                        }
+                        {info?.description && info?.config_order.length != 0 && <Separator borderColor="border.subtle" />}
+                        {info?.config_order.length != 0 &&
+                            <Box>
+                                <Stack gap='3.5'>
+                                    <Heading size='sm' color="fg.subtle">设置项</Heading>
+                                    {
+                                        info?.config_order.map((key) => (
+                                            <Config key={key} alias={alias} value={config[key]} info={info.config[key]} />
+                                        ))
+                                    }
+                                </Stack>
+                            </Box>
+                        }
+                    </Stack>
+                </Card.Body>
+            )}
+
             {isDangerous && (
                 <Alert
                     isOpen={dangerConfirm.open}
@@ -274,6 +276,6 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
                     onConfirm={() => { dangerConfirm.onClose(); handleExecute(); }}
                 />
             )}
-        </Card.Root >
+        </Card.Root>
     )
 }

--- a/src/components/Account/Module.tsx
+++ b/src/components/Account/Module.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Card, Flex, HStack, Heading, Separator, Stack, Tag, useDisclosure } from '@chakra-ui/react'
+import { useRef } from 'react'
 import { ConfigValue, ModuleInfo } from '@interfaces/Module';
 import { FiChevronDown, FiCopy, FiStar } from 'react-icons/fi';
 import { getAccountAreaSingleResultList, postAccountAreaSingle, putAccountConfig, getAccountConfig, putAccountConfigs } from '@api/Account';
@@ -6,7 +7,7 @@ import { getAccountAreaSingleResultList, postAccountAreaSingle, putAccountConfig
 import Alert from '../alert';
 import { AxiosError } from 'axios';
 import { Checkbox } from '../../components/ui/checkbox';
-import Config, { enqueueConfigSave } from './Config';
+import Config, { enqueueConfigSave, getErrorDescription } from './Config';
 import NiceModal from '@ebay/nice-modal-react';
 import ResultInfoModal from './ResultInfoModal';
 import ModuleSyncModal from './ModuleSyncModal';
@@ -51,22 +52,33 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
         }
 
         favMap[areaKey] = Array.from(areaFavs);
-        localStorage.setItem(favKey, JSON.stringify(favMap));
+        try {
+            localStorage.setItem(favKey, JSON.stringify(favMap));
+        } catch {
+            toaster.create({ type: 'error', title: '收藏保存失败', description: '本地存储不可用或已满' });
+            return;
+        }
 
         onConfigUpdate?.(`_fav_${info.key}`, isNowFav);
     };
 
+    // 用 ref 记最新模块开关，快速连点失败回滚不取过期闭包
+    const moduleEnabledRef = useRef(config[info.key]);
+    moduleEnabledRef.current = config[info.key];
+
     const onCheckedChange = (details: { checked: boolean | "indeterminate" }) => {
         const isChecked = !!details.checked;
-        const previousValue = config[info.key];
+        const previousValue = moduleEnabledRef.current;
 
         onConfigUpdate?.(info.key, isChecked);
+        moduleEnabledRef.current = isChecked;
 
         enqueueConfigSave(alias, () => putAccountConfig(alias, info?.key, isChecked)).then((response) => {
             toaster.create({ type: 'success', title: '保存成功', description: response });
-        }).catch((err: AxiosError) => {
-            onConfigUpdate?.(info.key, previousValue);
-            toaster.create({ type: 'error', title: '保存失败', description: (err.response?.data as string) || '网络错误' });
+        }).catch(async (err: AxiosError) => {
+            onConfigUpdate?.(info.key, previousValue as ConfigValue);
+            moduleEnabledRef.current = previousValue;
+            toaster.create({ type: 'error', title: '保存失败', description: await getErrorDescription(err) });
         });
     };
 
@@ -75,10 +87,10 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
         onOpen();
         postAccountAreaSingle(alias, info?.key).then(async (res) => {
             toaster.create({ type: 'success', title: '执行成功' });
-            onClose();
             await NiceModal.show(ResultInfoModal, { alias: alias, title: info?.name, resultInfo: res });
         }).catch(async (err: AxiosError) => {
-            toaster.create({ type: 'error', title: '执行失败', description: await (err.response?.data as Blob).text() || "网络错误" });
+            toaster.create({ type: 'error', title: '执行失败', description: await getErrorDescription(err) });
+        }).finally(() => {
             onClose();
         });
     }
@@ -88,11 +100,11 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
         toaster.create({ type: 'info', title: `正在获取${info?.name}的结果` });
         onOpen();
         getAccountAreaSingleResultList(alias, info?.key).then(async (res) => {
-            onClose();
             await NiceModal.show(ResultInfoModal, { alias: alias, title: info?.name, resultInfo: res });
         }).catch(async (err: AxiosError) => {
+            toaster.create({ type: 'error', title: '获取结果失败', description: await getErrorDescription(err) });
+        }).finally(() => {
             onClose();
-            toaster.create({ type: 'error', title: '获取结果失败', description: await (err.response?.data as Blob).text() || "网络错误" });
         });
     }
 
@@ -113,8 +125,13 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
         const targetAccounts = await NiceModal.show(ModuleSyncModal, { sourceAlias: alias, moduleName: info.name });
         if (!Array.isArray(targetAccounts) || targetAccounts.length === 0) return;
 
-        const normalizedTargets = targetAccounts.filter((item): item is string => typeof item === 'string');
-        if (normalizedTargets.length === 0) return;
+        const normalizedTargets = targetAccounts
+            .filter((item): item is string => typeof item === 'string')
+            .filter((item) => item !== alias);
+        if (normalizedTargets.length === 0) {
+            toaster.create({ type: 'warning', title: '没有可同步的目标账号' });
+            return;
+        }
 
         onOpen();
         try {
@@ -168,6 +185,15 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
         }
     }
 
+    const handleHeaderClick = () => {
+        // 折叠前先失焦，让 text/int/time 的 onBlur 先保存并回写父级
+        const ae = document.activeElement as HTMLElement | null;
+        if (ae && typeof ae.blur === 'function' && ae !== document.body) {
+            ae.blur();
+        }
+        window.setTimeout(() => onToggleExpand(), 0);
+    };
+
     return (
         <Card.Root
             colorPalette="brand"
@@ -180,17 +206,7 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
             _hover={{ shadow: 'md', borderColor: "blue.400" }}
             {...rest}
         >
-            <Card.Header
-                py={3}
-                cursor="pointer"
-                onClick={() => {
-                    // 折叠/展开前先让当前输入失焦，触发 Config 的 onBlur 保存，避免草稿被卸载丢掉
-                    const ae = document.activeElement as HTMLElement | null;
-                    if (ae && typeof ae.blur === 'function') ae.blur();
-                    // 等 blur 的同步 onChange/onBlur 入队后再切展开态
-                    window.setTimeout(() => onToggleExpand(), 0);
-                }}
-            >
+            <Card.Header py={3} cursor="pointer" onClick={handleHeaderClick}>
                 <Flex align="center" wrap="wrap" gap={2}>
                     <Box onClick={(e) => e.stopPropagation()} mr={{ base: 1, md: 1 }}>
                         <Checkbox
@@ -241,7 +257,7 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
                 </Flex>
             </Card.Header>
 
-            {/* 折叠时不挂 Config：条件渲染，兼容各版 Chakra */}
+            {/* 折叠卸载设置树省内存；Config 已回写 Area，再展开不会回到旧值 */}
             {isExpanded && (
                 <Card.Body pt={0} animation="fade-in 0.2s">
                     <Stack gap='1.5'>
@@ -257,7 +273,13 @@ export default function Module({ alias, areaKey, areaName, config, info, isOpen,
                                     <Heading size='sm' color="fg.subtle">设置项</Heading>
                                     {
                                         info?.config_order.map((key) => (
-                                            <Config key={key} alias={alias} value={config[key]} info={info.config[key]} />
+                                            <Config
+                                                key={key}
+                                                alias={alias}
+                                                value={config[key]}
+                                                info={info.config[key]}
+                                                onConfigUpdate={onConfigUpdate}
+                                            />
                                         ))
                                     }
                                 </Stack>

--- a/src/routes/daily/_sidebar/account/$account.tsx
+++ b/src/routes/daily/_sidebar/account/$account.tsx
@@ -3,12 +3,12 @@ import { useEffect, useMemo, useState } from 'react';
 import { FiActivity, FiCheck, FiStar, FiTarget, FiUserX } from 'react-icons/fi';
 
 import { AccountResponse } from '@interfaces/Account';
-import Area from '@components/Account/Area';
+import Area, { clearAreaConfigCache } from '@components/Account/Area';
 import ConfigImportExport from '@components/Account/ConfigImportExport.tsx';
 import Info from '@components/Account/Info';
 import { createFileRoute } from '@tanstack/react-router';
 import { getAccount, postAccountAreaDaily } from '@api/Account';
-import { toaster } from '@components/ui/toaster';
+import { toaster } from '../../../../components/ui/toaster';
 
 export const Route = createFileRoute('/daily/_sidebar/account/$account')({
     component: AccountComponent,
@@ -69,12 +69,26 @@ function AccountComponent() {
         }
     };
 
+    // 导入配置成功：账号基础信息刷新 + 丢掉旧区服配置缓存（下次进区服拉新配置）
+    const handleImportSuccess = async () => {
+        clearAreaConfigCache(accountInfo?.alias || account);
+        await refreshAccountData();
+    };
+
     useEffect(() => {
         setActiveTab(initialTab);
         setDisplayName(localStorage.getItem(`autopcr_displayName_${account}`) || account);
         const st = (initialAccountInfo as any)?.daily_clean_time?.status;
         if (st) setCleanStatus(st);
     }, [initialAccountInfo, initialTab, account]);
+
+    // 离开本账号详情（回一览 / 换账号）时清缓存，把内存还回去
+    useEffect(() => {
+        const alias = account;
+        return () => {
+            clearAreaConfigCache(alias);
+        };
+    }, [account]);
 
     const currentArea =
         activeTab !== '0' && accountInfo?.area
@@ -131,8 +145,6 @@ function AccountComponent() {
     return (
         <Tabs.Root
             lazyMount
-            // Area tabs contain many form controls. Keeping every visited panel mounted
-            // makes each later tab change reconcile an ever-growing hidden component tree.
             unmountOnExit
             variant="plain"
             value={activeTab}
@@ -231,7 +243,7 @@ function AccountComponent() {
                     <ConfigImportExport
                         alias={accountInfo?.alias}
                         areas={accountInfo?.area}
-                        onImportSuccess={refreshAccountData}
+                        onImportSuccess={handleImportSuccess}
                     />
                 </Tabs.Content>
 

--- a/src/routes/daily/_sidebar/account/$account.tsx
+++ b/src/routes/daily/_sidebar/account/$account.tsx
@@ -28,7 +28,6 @@ function AccountComponent() {
     const [favOnlyMap, setFavOnlyMap] = useState<Record<string, boolean>>({});
     const [cleanLoading, setCleanLoading] = useState(false);
 
-    // 与一览一致：用清理结果的 status 驱动按钮旁徽章（不常驻死字）
     const [cleanStatus, setCleanStatus] = useState<string>(
         () => (initialAccountInfo as any)?.daily_clean_time?.status || '',
     );
@@ -69,20 +68,27 @@ function AccountComponent() {
         }
     };
 
-    // 导入配置成功：账号基础信息刷新 + 丢掉旧区服配置缓存（下次进区服拉新配置）
     const handleImportSuccess = async () => {
         clearAreaConfigCache(accountInfo?.alias || account);
         await refreshAccountData();
     };
 
+    // 仅切换账号时重置 Tab；刷新 accountInfo 不要把用户正在看的 Tab 打回初始
     useEffect(() => {
         setActiveTab(initialTab);
         setDisplayName(localStorage.getItem(`autopcr_displayName_${account}`) || account);
         const st = (initialAccountInfo as any)?.daily_clean_time?.status;
         if (st) setCleanStatus(st);
-    }, [initialAccountInfo, initialTab, account]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [account]);
 
-    // 离开本账号详情（回一览 / 换账号）时清缓存，把内存还回去
+    useEffect(() => {
+        setDisplayName(localStorage.getItem(`autopcr_displayName_${account}`) || account);
+        const st = (initialAccountInfo as any)?.daily_clean_time?.status;
+        if (st) setCleanStatus(st);
+    }, [initialAccountInfo, account]);
+
+    // 离开本账号详情时清缓存
     useEffect(() => {
         const alias = account;
         return () => {
@@ -107,12 +113,11 @@ function AccountComponent() {
             localStorage.getItem(`autopcr_displayName_${a}`) || displayName || a;
 
         setCleanLoading(true);
-        setCleanStatus(''); // 清理中先清掉旧徽章，结束后再按真实 status 显示
+        setCleanStatus('');
         toaster.create({ type: 'info', title: `开始为${nameForUi}清理日常...` });
 
         try {
             const res = await postAccountAreaDaily(a);
-            // 与一览相同数据源：daily_clean_time.status
             const st =
                 (res as any)?.daily_clean_time?.status ||
                 (res as any)?.status ||
@@ -122,7 +127,6 @@ function AccountComponent() {
             sessionStorage.setItem('autopcr_need_refresh_dashboard', '1');
             await refreshAccountData();
 
-            // toaster 只保留原来就能弹的那套，不另造文案体系
             if (st === '错误') {
                 toaster.create({ type: 'error', title: `${nameForUi}清日常结束` });
             } else if (st === '警告' || st === '中止') {
@@ -226,7 +230,6 @@ function AccountComponent() {
                         >
                             <FiTarget /> 立刻清理
                         </Button>
-                        {/* 与一览 statusMeta 一致：出现在清理按钮右边 */}
                         {statusMeta && (
                             <Tag.Root size="sm" colorPalette={statusMeta.color} variant="subtle">
                                 <Tag.StartElement>{statusMeta.icon}</Tag.StartElement>


### PR DESCRIPTION
## 变更概述
本次 PR 对 `account` 详情页、`Area` 区服组件、`Module` 模块卡片以及仪表盘（`DashBoard`）进行了系统性重构，主要包含：

- **引入区服配置缓存**（`Area` 新增 `areaConfigCache`），减少重复 API 请求，提升切换 Tab 和返回详情页的响应速度，现在应该可以做到在tab之间反复切换也不会卡顿了。
- **优化模块折叠/展开交互**（`Module` 改用 Chakra UI `Collapsible` 组件，并增加输入框失焦保护）。
- **增强仪表盘批量操作**（卡片视图增加 `Checkbox` 选择，清理逻辑统一为“选中优先”）。
- **完善账号显示名编辑，使默认账号的双视图编辑统一，且增加取消机制**。
<img width="2937" height="731" alt="image" src="https://github.com/user-attachments/assets/1b28cd31-e349-4ed0-a5c2-0a0eae2f045c" />
- **新增缓存清理机制**（`$account.tsx` 在导入配置成功和组件卸载时调用 `clearAreaConfigCache`）。

## 主要文件改动

### `$account.tsx`
- 导入 `clearAreaConfigCache`，在 `handleImportSuccess` 中调用，确保导入后区服配置缓存失效，下次加载拉取最新数据。
- 新增 `useEffect` 返回清理函数，组件卸载时清除当前账号的缓存，释放内存。
- `ConfigImportExport` 的 `onImportSuccess` 回调替换为 `handleImportSuccess`（内部调用 `refreshAccountData` 并清理缓存）。

### `Area.tsx`
- 新增 `areaConfigCache` 及相关工具函数（`getCachedAreaConfig`、`setCachedAreaConfig`、`clearAreaConfigCache`）。
- `useEffect` 优先从缓存读取数据，命中则直接使用并跳过网络请求；未命中再调用 API，并将结果存入缓存。
- `handleConfigUpdate` 更新 state 的同时同步写回缓存，保证缓存与 UI 一致。
- 导出 `clearAreaConfigCache` 供外部调用。

### `Module.tsx`
- 用 `<Collapsible.Root>` + `<Collapsible.Content>` 替换原本的条件渲染 `{isExpanded && ...}`，实现平滑展开/收起动画。
- 在折叠切换前主动使当前输入框失焦（`document.activeElement.blur()`），防止未保存的草稿丢失。
- 保存配置改用 `enqueueConfigSave`（来自 `Config` 组件），实现防抖和队列化，减少频繁请求。
- 微调间距（`gap`、`padding`）和样式细节。

### `DashBoard.tsx`
- 卡片视图（非表格视图）中新增 `Checkbox` 用于多选，同时保留原有的 `Radio` 用于选择默认账号（二者功能独立）。
- “清理全部”按钮逻辑优化：若存在选中的账号，则仅清理选中的账号；否则清理全部（不再依赖视图模式）。
- 表格视图列宽和内边距调整，账号显示名输入框增加自动聚焦与光标定位（`useEffect` + `setSelectionRange`）。
- 优化删除按钮的尺寸和悬停样式。
- 默认账号设置改为使用 `handleDefaultAccount`，并更新 `userInfo` 状态以保持一致性。

## 兼容性与依赖
- 本 PR 要求 `Config` 组件导出 `enqueueConfigSave` 函数（已同步更新）。
- 所有改动向后兼容，不影响现有 API 响应结构和业务逻辑。
- 缓存使用内存 Map，无需额外存储依赖，仅在组件生命周期内生效。

## 测试建议
1. **缓存有效性**：进入账号详情页，切换区服 Tab，观察 Network 请求是否减少；修改某个模块配置后切回，配置是否保持最新。
2. **导入配置**：导入一个 `.autopcrcfg` 文件，检查区服缓存是否被清除（下次加载会重新请求）。
3. **模块折叠/展开**：展开模块，修改其中的 Input/Select 后直接点击模块头部折叠，确认修改未丢失且已保存。
4. **仪表盘多选**：在卡片视图下勾选多个账号，点击“清理全部”按钮，观察只清理选中的账号；取消所有选中则清理全部。
5. **显示名编辑**：点击账号名称进入编辑状态，修改后按 Enter 或失焦保存，冲突检测是否正常；按 Escape 取消编辑。

## 回归影响范围
- 账号详情页（`/daily/_sidebar/account/$account`）
- 仪表盘（`/daily/_sidebar/account`）
- 所有区服模块的配置保存与执行
- 配置导入/导出功能

## 已知风险
- 若 `Config` 组件未同步更新 `enqueueConfigSave`，会导致保存报错（需确保 PR 一并合入）。
- 缓存机制依赖 `alias` 和 `key` 组合作为键，若 `alias` 变化（如账号重命名）可能导致旧缓存残留，但无负面影响（自动清理）。