### PR TITLE
修复注册限流提示与重复提交

### DIFF
--- a/src/api/APIUtils.ts
+++ b/src/api/APIUtils.ts
@@ -38,6 +38,11 @@ export const Fetch = axios.create({
  */
 const getErrorMessage = (error: AxiosError): string => {
     if (error.response) {
+        if (error.response.status === 429) {
+            const retryAfter = Number(error.response.headers['retry-after']);
+            if (Number.isFinite(retryAfter)) return `请在 ${Math.ceil(retryAfter)} 秒后重试`;
+        }
+
         const data = error.response.data as any;
         // 如果后端返回的是字符串，直接使用；如果是对象，尝试获取 message 或 error 字段
         if (typeof data === 'string') return data;

--- a/src/components/Login/LoginWithPasswordComponent.tsx
+++ b/src/components/Login/LoginWithPasswordComponent.tsx
@@ -107,6 +107,7 @@ export default function LoginWithPasswordComponent() {
                         </Button>
                         <Button
                             colorPalette="brand"
+                            loading={isSubmitting}
                             onClick={handleSubmit(handleRegister)}
                         >
                             注册


### PR DESCRIPTION
## 问题

注册接口返回 429 时，前端只显示通用错误文案，无法提示剩余等待时间；注册按钮在请求期间也没有提交状态。

## 修改内容

- 读取后端返回的数字型 `Retry-After`，显示剩余等待秒数
- 注册请求提交期间显示按钮加载状态，避免重复提交

## 验证

- `pnpm build`
- 最终差异仅涉及 2 个文件，共新增 6 行代码